### PR TITLE
Pull ReRequest: Fix for "Cloning HG repo to Git creates "uncheck-out-able" repositories". And upgrade for filenames transcoding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,4 +26,14 @@ install-doc: doc
 	install -d -m 755 $(D)$(mandir)/
 	install -m 644 doc/git-remote-hg.1 $(D)$(mandir)/git-remote-hg.1
 
-.PHONY: all test install install-doc clean
+pypi:
+	-rm -rf dist build
+	python setup.py sdist bdist_wheel
+
+pypi-upload:
+	twine upload dist/*
+
+pypi-test:
+	twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+
+.PHONY: all test install install-doc clean pypy pypy-upload

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ install-doc: doc
 
 pypi:
 	version=`git describe --tags ${REV}` && \
-		sed -i "s/version = .*/version = '$$version'/" setup.py
+		sed -i "s/version = .*/version = '$$version'[1:]/" setup.py
 	-rm -rf dist build
 	python setup.py sdist bdist_wheel
 

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,8 @@ install-doc: doc
 	install -m 644 doc/git-remote-hg.1 $(D)$(mandir)/git-remote-hg.1
 
 pypi:
+	version=`git describe --tags ${REV}` && \
+		sed -i "s/version = .*/version = '$$version'/" setup.py
 	-rm -rf dist build
 	python setup.py sdist bdist_wheel
 

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -9,7 +9,7 @@ git clone "hg::http://selenic.com/repo/hello"
 To enable this, simply add the 'git-remote-hg' script anywhere in your `$PATH`:
 
 --------------------------------------
-wget https://raw.github.com/felipec/git-remote-hg/master/git-remote-hg -O ~/bin/git-remote-hg
+wget https://raw.github.com/mnauw/git-remote-hg/master/git-remote-hg -O ~/bin/git-remote-hg
 chmod +x ~/bin/git-remote-hg
 --------------------------------------
 
@@ -127,5 +127,4 @@ https://github.com/felipec/git/wiki/Comparison-of-git-remote-hg-alternatives[her
 
 == Contributing ==
 
-Send your patches to the mailing list git-fc@googlegroups.com (no need to
-subscribe).
+Please file an issue with some patches or a pull-request.

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -295,6 +295,55 @@ git-to-git fetch (or clone).
 As such (and as said), this approach aims for plain-and-simple safety, but only
 within a local scope (git repo).
 
+=== Mercurial Subrepository Support ===
+
+Both Git and Mercurial support a submodule/subrepo system.
+In case of Git, URLs are managed in `.gitmodules`, submodule state is tracked
+in tree objects and only Git submodules are supported.
+Mercurial manages URLs in `.hgsub`, records subrepo state in `.hgsubstate` and
+supports Git, Mercurial and Subversion subrepos (at time of writing).
+Merely the latter diversity in subrepo types shows that somehow mapping Mercurial
+"natively" to git submodules is not quite evident.  Moreover, while one might
+conceivably devise such a mapping restricted to git and hg subrepos, any such would
+seem error-prone and fraught with all sorts of tricky cases and inconvenient
+workflow handling (innovative robust suggestions are welcome though ...)
+
+So, rather than overtaking the plumbing and ending up with stuffed drain further on,
+the approach here is (again) to keep it plain-and-simple.  That is, provide some
+git-ish look-and-feel helper script commands for setting up and manipulating
+subrepos.  And so (if the alias mentioned above has been defined), `git hg sub`
+provides commands similar to `git submodule` that accomplish what is otherwise
+taken care of by the Mercurial subrepo support.
+The latter is obviously extended to be git-aware in that e.g. a Mercurial subrepo
+is cloned as a git-hg subrepo and translation back-and-forth between hg changeset id
+and git commit hash is also performed where needed.  There is no support though
+for Subversion subrepos.
+
+As with the other commands, see the help description for the proper details,
+but the following example session may clarify the principle:
+
+--------------------------------------
+% git clone hg::hgparentrepo
+# bring in subrepos in proper location:
+% git hg sub update
+# do some work
+% git pull --rebase origin
+# update subrepo state:
+% git hg sub update
+# do work in subrepo and push
+% ( cd subrepo && git push origin HEAD:master )
+# fetch to update refs/notes/hg (or enable remote-hg.push-updates-notes)
+% ( cd subrepo && git fetch origin )
+# update .hgsubstate to subrepo HEAD:
+% git hg sub upstate
+% git add .hgsubstate
+# add more, commit and push as intended
+--------------------------------------
+
+Note that the refspec `HEAD:master` is needed if working with detached `HEAD`
+in subrepo, and that pushing such refspec is actually supported now in a git-hg subrepo
+as explained <<no-limitations, earlier>>.
+
 == Contributing ==
 
 Please file an issue with some patches or a pull-request.

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -226,6 +226,20 @@ also be enabled on an existing one by the following setting.
 --------------------------------------
 Note, however, that one should then perform a fetch from each relevant remote
 to fully complete the conversion (prior to subsequent pushing).
+--------------------------------------
+% git config --global remote-hg.remove-username-quotes false
+
+By default, for backwards compatibility with earlier versions,
+git-remote-hg removes quotation marks from git usernames
+(e.g. 'Raffaello "Raphael" Sanzio da Urbino <raphael@example.com>'
+would become 'Raffaello Raphael Sanzio da Urbino
+<raphael@example.com>').  This breaks round-trip compatibility; a git
+commit by an author with quotes would become an hg commit without,
+and if re-imported into git, would get a different SHA1.
+
+To restore round-trip compatibility (at the cost of backwards
+compatibility with commits converted by older versions of
+git-remote-hg), turn 'remote-hg.remove-username-quotes' off.
 
 === Helper Commands ===
 

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -24,6 +24,7 @@ to be appropriately merged upstream):
 
 * eliminates a number of <<limitations, limitations>> as mentioned below
 * properly annotates copy/rename when pushing new commits to Mercurial
+* avoids clutter of `refs/hg/...` by keeping these implementation details really private
 
 See sections below or sidemarked notes for more details.
 ****

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -27,6 +27,7 @@ to be appropriately merged upstream):
 * adds a 'git-hg-helper' script than can aid in the git-hg interaction workflow
 * provides enhanced bidirectional git-hg safety
 * avoids clutter of `refs/hg/...` by keeping these implementation details really private
+* more robust and efficient fetching
 
 See sections below or sidemarked notes for more details.
 ****
@@ -191,11 +192,12 @@ To tweak how 'git-remote-hg' decides on a copy/rename, use e.g:
 == Additional Features ==
 
 === Miscellaneous Tweaks ===
-
 Other than <<no-limitations, removing the limitations>> as mentioned above,
-a number of issues (either so reported in issue tracking or not) have been
-addressed here (e.g. notes handling, `fetch --prune` support, etc), some of
-which have been highlighted above.
+a number of issues (either so reported in
+https://github.com/felipec/git-remote-hg/issues[issue tracking] or not) have been
+addressed here, e.g. notes handling, `fetch --prune` support, recovering
+from a `strip` on remote repo, tracking remote changes to import (if any) in a
+safe, robust and efficient way, etc.  Some of these have been highlighted above.
 
 For example, the `refs/hg/...` refs are really an implementation detail
 that need not clutter up the (visible) ref space.  So, in as much as they
@@ -213,9 +215,7 @@ a remote helper.  This is similar to e.g. 'git-svn' being a separate program
 altogether.  These subcommands
 
 * provide conversion from a hg changeset id to a git commit hash, or vice versa
-* provide consistency maintenance on internal `git-remote-hg` metadata marks,
-which might on occasion be required or useful for efficiency
-(e.g. to avoid full fetch history processing following strip on a large Mercurial repo).
+* provide consistency and cleanup maintenance on internal `git-remote-hg` metadata marks
 * provide optimization of git marks of a fetch-only remote
 
 See the helper script commands' help description for further details.
@@ -226,11 +226,13 @@ as `git hg`:
 % git config --global alias.hg '!git-hg-helper'
 --------------------------------------
 
-With that in place, running `git hg marks <remote>` after initial fetch from (large)
+With that in place, running `git hg gc <remote>` after initial fetch from (large)
 <remote> will save quite some space in the git marks file.  Not to mention some time
-each time is loaded and saved again (upon fetch).  If the remote is ever pushed
+each time it is loaded and saved again (upon fetch).  If the remote is ever pushed
 to, the marks file will similarly be squashed, but for a fetch-only <remote>
-the aforementioned command will do.
+the aforementioned command will do.  It may also be needed to run aforementioned
+command after a `git gc` has been performed.  You will notice the need
+when `git-fast-import` or `git-fast-export` complain about not finding objects ;-)
 
 In addition, the helper also provides support routines for `git-remote-hg` that
 provide for increased (or at least safer) git-hg bidirectionality.

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -205,14 +205,6 @@ If somehow your workflow relies on having these in the old place:
 % git config --global remote-hg.show-private-refs true
 --------------------------------------
 
-The `refs/notes/hg` mentioned above that provide info on corresponding hg
-changeset are so far only updated upon a fetch.  If you prefer to have
-these notes as soon as possible, then a push can be made to do some extra
-work on this:
---------------------------------------
-% git config --global remote-hg.push-updates-notes true
---------------------------------------
-
 === Helper Commands ===
 
 Beyond that, a 'git-hg-helper' script has been added that can aid in the git-hg

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -195,8 +195,8 @@ To tweak how 'git-remote-hg' decides on a copy/rename, use e.g:
 Other than <<no-limitations, removing the limitations>> as mentioned above,
 a number of issues (either so reported in
 https://github.com/felipec/git-remote-hg/issues[issue tracking] or not) have been
-addressed here, e.g. notes handling, `fetch --prune` support, recovering
-from a `strip` on remote repo, tracking remote changes to import (if any) in a
+addressed here, e.g. notes handling, `fetch --prune` support, correctly fetching
+after a `strip` on remote repo, tracking remote changes to import (if any) in a
 safe, robust and efficient way, etc.  Some of these have been highlighted above.
 
 For example, the `refs/hg/...` refs are really an implementation detail

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -228,6 +228,7 @@ Note, however, that one should then perform a fetch from each relevant remote
 to fully complete the conversion (prior to subsequent pushing).
 --------------------------------------
 % git config --global remote-hg.remove-username-quotes false
+--------------------------------------
 
 By default, for backwards compatibility with earlier versions,
 git-remote-hg removes quotation marks from git usernames

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -243,6 +243,23 @@ also be enabled on an existing one by the following setting.
 --------------------------------------
 Note, however, that one should then perform a fetch from each relevant remote
 to fully complete the conversion (prior to subsequent pushing).
+
+Some Mercurial names (of branches, bookmarks, tags) may not be a valid git
+refname. See e.g. `man git-check-ref-format` for a rather involved set of rules.
+Moreover, while a slash `/` is allowed, it is not supported to have both a `parent`
+and `parent/child` branch (though only the latter is allowed). So, pending some
+"nice" bidirectional encoding (not even e.g. URL encoding is safe actually), it is more
+likely that only a few instances (out of a whole Mercurial repo) are
+problematic.  This could be handled by a single-branch clone and/or configuring
+a suitable refspec.  However, it might be more convenient to simply filter out a
+few unimportant pesky cases, which can be done by configuring a regural
+expression in following setting:
+--------------------------------------
+% git config remote-hg.ignore-name nasty/nested/name
+--------------------------------------
+Recall also that a config setting can be provided at clone time
+(command line using `--config` option).
+
 --------------------------------------
 % git config --global remote-hg.remove-username-quotes false
 --------------------------------------

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -18,12 +18,14 @@ That's it :)
 Obviously you will need Mercurial installed.
 
 ****
-At present, this "working copy"/fork adds the following features
+At present, this "working copy"/fork <<add-features, adds the following features>>
 (and I would prefer it is indeed rather a "working copy"
 to be appropriately merged upstream):
 
 * eliminates a number of <<limitations, limitations>> as mentioned below
 * properly annotates copy/rename when pushing new commits to Mercurial
+* adds a 'git-hg-helper' script than can aid in the git-hg interaction workflow
+* provides enhanced bidirectional git-hg safety
 * avoids clutter of `refs/hg/...` by keeping these implementation details really private
 
 See sections below or sidemarked notes for more details.
@@ -184,6 +186,114 @@ To tweak how 'git-remote-hg' decides on a copy/rename, use e.g:
 --------------------------------------
 % git config --global remote-hg.fast-export-options '-M -C -C'
 --------------------------------------
+
+[[add-features]]
+== Additional Features ==
+
+=== Miscellaneous Tweaks ===
+
+Other than <<no-limitations, removing the limitations>> as mentioned above,
+a number of issues (either so reported in issue tracking or not) have been
+addressed here (e.g. notes handling, `fetch --prune` support, etc), some of
+which have been highlighted above.
+
+For example, the `refs/hg/...` refs are really an implementation detail
+that need not clutter up the (visible) ref space.  So, in as much as they
+are still relevant, these are now kept elsewhere out of sight.
+If somehow your workflow relies on having these in the old place:
+--------------------------------------
+% git config --global remote-hg.show-private-refs true
+--------------------------------------
+
+The `refs/notes/hg` mentioned above that provide info on corresponding hg
+changeset are so far only updated upon a fetch.  If you prefer to have
+these notes as soon as possible, then a push can be made to do some extra
+work on this:
+--------------------------------------
+% git config --global remote-hg.push-updates-notes true
+--------------------------------------
+
+=== Helper Commands ===
+
+Beyond that, a 'git-hg-helper' script has been added that can aid in the git-hg
+interaction workflow with a number of subcommands that are not in the purview of
+a remote helper.  This is similar to e.g. 'git-svn' being a separate program
+altogether.  These subcommands
+
+* provide conversion from a hg changeset id to a git commit hash, or vice versa
+* provide consistency maintenance on internal `git-remote-hg` metadata marks,
+which might on occasion be required or useful for efficiency
+(e.g. to avoid full fetch history processing following strip on a large Mercurial repo).
+* provide optimization of git marks of a fetch-only remote
+
+See the helper script commands' help description for further details.
+It should simply be installed (`$PATH` accessible) next to 'git-remote-hg'.
+Following git alias is probably also convenient as it allows invoking the helper
+as `git hg`:
+--------------------------------------
+% git config --global alias.hg '!git-hg-helper'
+--------------------------------------
+
+With that in place, running `git hg marks <remote>` after initial fetch from (large)
+<remote> will save quite some space in the git marks file.  Not to mention some time
+each time is loaded and saved again (upon fetch).  If the remote is ever pushed
+to, the marks file will similarly be squashed, but for a fetch-only <remote>
+the aforementioned command will do.
+
+In addition, the helper also provides support routines for `git-remote-hg` that
+provide for increased (or at least safer) git-hg bidirectionality.
+
+Before explaining how it helps, let's first elaborate on what is really
+meant by the above _bidirectionality_ since it can be regarded in 2 directions.
+From the git repo point of view, one can push to a hg repo and then fetch (or
+clone) back to git. Or one could have fetched a changeset from some hg repo and
+then push this back to (another) hg clone.  So what happens in either case? In the
+former case, from git to hg and then back, things work out ok whether or not in
+hg-git compatibility mode.  In the latter case, it is very likely (but
+ultimately not guaranteed) that it works out in hg-git compatibility mode, and far
+less likely otherwise.
+
+Most approaches on bidirectionality try to go for the "mapping" way.
+That is, find a way to map all Mercurial (meta)data somewhere into git;
+in the commit message, or in non-standard ways in extra headers in commit objects
+(e.g. the latest hg-git approach).  The upside of this is that such a git repo can be
+cloned to another git repo, and then one can push back into hg which will/should
+turn out ok.  The downside is setting up such a mapping in the first place,
+avoiding the slightest error in translating authors, timestamps etc,
+and maintaining all that whenever there is some Mercurial API/ABI breakage.
+
+The approach here is to consider a typical git-hg interaction workflow and to
+ensure simple/safe bidirectionality in such a setting.  That is, you are (obviously)
+in a situation having to deal with some Mercurial repo and quite probably
+with various clones as well. The objective is to fetch from these repos/clones,
+work in git and then push back.  And in the latter case, one needs to make sure
+that hg changesets from one hg clone end up *exactly* that way in another hg
+clone (or the git-hg bridge usage might not be so appreciated).  Such pushes are
+probably not recommended workflow practice, but no accidents or issues should
+arise from any push in these circumstances. There is less interest in this setting,
+however, for (git-wise) cloning around the derived git repo.
+
+Now, depending on your workflow and to ensure the above behaves well,
+following setting can be enabled as preferred:
+
+--------------------------------------
+% git config --global remote-hg.check-hg-commits fail
+% git config --global remote-hg.check-hg-commits push
+--------------------------------------
+
+If not set, the behaviour is as before; pushing a commit based on hg changeset
+will again transform the latter into a new hg changeset which may or may not
+match the original (as described above).
+If set to `fail`, it will reject and abort the push.
+If set to `push`, it will re-use the original changeset in a Mercurial native
+way (rather than creating a new one).  The latter guarantees the changeset ends
+up elsewhere as expected (regardless of conversion mapping or ABI).
+
+Note that identifying and re-using the hg changeset relies on metadata
+(`refs/notes/hg` and marks files) that is not managed or maintained by any
+git-to-git fetch (or clone).
+As such (and as said), this approach aims for plain-and-simple safety, but only
+within a local scope (git repo).
 
 == Contributing ==
 

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -108,6 +108,23 @@ However, some of these features require very new versions of 'git-remote-hg',
 so you might have better luck simply specifying the username and password in
 the URL.
 
+=== Submodules ===
+
+Hg repositories can be used as git submodule, but this requires to allow the hg procotol to be used by git submodule commands:
+
+--------------------------------------
+git config protocol.hg.allow always
+--------------------------------------
+
+Or adding manually the following to your git configuration file:
+
+--------------------------------------
+[protocol "hg"]
+        allow = always
+--------------------------------------
+
+This can be done per-repository, every time after a clone, or globally in the global .gitconfig (using the --global command-line option).
+
 === Caveats ===
 
 The only major incompatibility is that Git octopus merges (a merge with more

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -27,7 +27,9 @@ to be appropriately merged upstream):
 * adds a 'git-hg-helper' script than can aid in the git-hg interaction workflow
 * provides enhanced bidirectional git-hg safety
 * avoids clutter of `refs/hg/...` by keeping these implementation details really private
-* more robust and efficient fetching
+* more robust and efficient fetching, especially so when fetching or cloning from multiple
+  Mercurial clones which will only process changesets not yet fetched from elsewhere
+  (as opposed to processing everything all over again)
 
 See sections below or sidemarked notes for more details.
 ****
@@ -206,6 +208,24 @@ If somehow your workflow relies on having these in the old place:
 --------------------------------------
 % git config --global remote-hg.show-private-refs true
 --------------------------------------
+
+More importantly, a significantly more efficient workflow is achieved using
+one set of shared marks files for all remotes (which also forces a local repo
+to use an internal proxy clone).
+The practical consequence is that fetching from a newly added remote hg repo
+does not require another (lengthy) complete import
+(as the original clone) but will only fetch additional changesets (if any).
+The same goes for subsequent fetching from any hg remote; what was fetched
+and imported from some remote need not be imported again from another.
+Operating in this shared mode also has the added advantage
+of correctly pushing after a `strip` on a remote.
+This shared-marks-files behaviour is the default on a fresh repo clone.  It can
+also be enabled on an existing one by the following setting.
+--------------------------------------
+% git config --global remote-hg.shared-marks true
+--------------------------------------
+Note, however, that one should then perform a fetch from each relevant remote
+to fully complete the conversion (prior to subsequent pushing).
 
 === Helper Commands ===
 

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -17,6 +17,17 @@ That's it :)
 
 Obviously you will need Mercurial installed.
 
+****
+At present, this "working copy"/fork adds the following features
+(and I would prefer it is indeed rather a "working copy"
+to be appropriately merged upstream):
+
+* eliminates a number of <<limitations, limitations>> as mentioned below
+* properly annotates copy/rename when pushing new commits to Mercurial
+
+See sections below or sidemarked notes for more details.
+****
+
 == Configuration ==
 
 If you want to see Mercurial revisions as Git commit notes:
@@ -107,6 +118,7 @@ Closed branches are not supported; they are not shown and you can't close or
 reopen. Additionally in certain rare situations a synchronization issue can
 occur (https://github.com/felipec/git/issues/65[Bug #65]).
 
+[[limitations]]
 Limitations of the remote-helpers' framework apply. In particular, these
 commands don't work:
 
@@ -114,16 +126,63 @@ commands don't work:
 * `git push origin old:new` (it will push 'old') (patches available)
 * `git push --dry-run origin branch` (it will push) (patches available)
 
+****
+Another limitation is that if `git log` reports a rename, this will not survive
+the push and Mercurial will not be aware of a rename (and similarly so for copy).
+Though Mercurial would know about it if you *manually* ran `git-format-patch`
+followed by a `hg apply -s`, which is not the nice way to go obviously.
+
+Actually, scratch the limitations above ascribed to the remote-helpers framework.
+They are not limitations of the framework, but are due to how the original
+implementation of 'git-remote-hg' interacts with it.
+Using the remote-helpers framework in only a slightly different way has none
+of the above limitations.  See the <<no-limitations, relevant section>>
+below for more details.
+****
+
 == Other projects ==
 
 There are other 'git-remote-hg' projects out there, do not confuse this one,
-this is the one distributed officially by the Git project:
+this is the one distributed officially by the Git project
+(_though actually no longer so nowadays_):
 
 * https://github.com/msysgit/msysgit/wiki/Guide-to-git-remote-hg[msysgit's git-remote-hg]
 * https://github.com/rfk/git-remote-hg[rfk's git-remote-hg]
 
 For a comparison between these and other projects go
 https://github.com/felipec/git/wiki/Comparison-of-git-remote-hg-alternatives[here].
+
+[[no-limitations]]
+== Limitations (or not) ==
+
+If interested in some of technical details behind this explanation, then also
+see the relevant section in 'git-remote-hg' manpage.  Otherwise, the general
+idea is presented here.
+
+More precisely and simply, the <<limitations, mentioned limitations>> are indeed
+limitations of the `export` capability of
+https://www.kernel.org/pub/software/scm/git/docs/gitremote-helpers.html[gitremote-helpers(1)]
+framework.  However, the framework also supports a `push` capability and when this
+is used appropriately in the remote helper the aforementioned limitations do not apply.
+In the case of `export` capability, git-core will internally invoke `git-fast-export`
+and the helper will process this data and hand over generated changesets to Mercurial.
+In the case of `push` capability, git informs the helper what (refs) should go where,
+and the helper is free to ponder about this and take the required action, such as
+to invoke `git-fast-export` itself (with suitable options) and process its output
+the same way as before (and over to Mercurial).
+
+And so;
+
+* `git push origin :branch-to-delete` will delete the bookmark `branch-to-delete` on remote
+* `git push --dry-run origin branch` will not touch the remote
+(or any local state, except for local helper proxy repo)
+* `git push origin old:new` will push `old` onto `new` in the remote
+* `git push origin <history-with-copy/rename>` will push copy/rename aware Mercurial revisions
+
+To tweak how 'git-remote-hg' decides on a copy/rename, use e.g:
+--------------------------------------
+% git config --global remote-hg.fast-export-options '-M -C -C'
+--------------------------------------
 
 == Contributing ==
 

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -13,6 +13,13 @@ wget https://raw.github.com/mnauw/git-remote-hg/master/git-remote-hg -O ~/bin/gi
 chmod +x ~/bin/git-remote-hg
 --------------------------------------
 
+In Windows, you also need to put and an NTFS symbolic link named `python2.exe` somewhere
+on your `$PATH` pointing to your Python 2 executable:
+
+--------------------------------------
+mklink <path to link> <path to python.exe>
+--------------------------------------
+
 That's it :)
 
 Obviously you will need Mercurial installed.

--- a/doc/git-remote-hg.txt
+++ b/doc/git-remote-hg.txt
@@ -58,6 +58,25 @@ If you want 'git-remote-hg' to be compatible with 'hg-git', and generate exactly
 % git config --global remote-hg.hg-git-compat true
 --------------------------------------
 
+If you would like (why?) the old behaviour (export capability)
+where various limitations apply:
+
+--------------------------------------
+% git config --global remote-hg.capability-push false
+--------------------------------------
+
+In the new behaviour, performing a git push will make git search for and detect
+file rename and copy and turn this into Mercurial commit metadata.  To tweak how this
+detection happens, e.g. have it search even more:
+
+--------------------------------------
+% git config --global remote-hg.fast-export-options '-M -C -C'
+--------------------------------------
+
+The default otherwise is simply `-M -C`.  See also e.g.
+https://www.kernel.org/pub/software/scm/git/docs/git-log.html[git-log(1) manpage]
+for more details on the options used to tweak this.
+
 NOTES
 -----
 
@@ -119,3 +138,41 @@ would only see the latest head.
 Closed branches are not supported; they are not shown and you can't close or
 reopen. Additionally in certain rare situations a synchronization issue can
 occur (https://github.com/felipec/git/issues/65[Bug #65]).
+
+TECHNICAL DISCUSSION
+--------------------
+
+As `git-remote-hg` is a developer tool after all, it might be interesting to know a
+bit about what is going on behind the scenes, without necessarily going into all the
+details.
+
+So let's first have a look in the `.git/hg` directory, which typically
+contains a subdirectory for each remote Mercurial repo alias, as well as a `.hg`
+subdirectory.  If the Mercurial repo is a local one, it will (again typically)
+only contain a `marks-git` and a `marks-hg` file.  If the repo is a remote one,
+then the `clone` contains, well, a local clone of the remote.  However, all
+these clones share storage through the `.hg` directory mentioned previously (so
+they do not add up separately). During a fetch/push, the local (proxy) repo is
+used as an intermediate stage. If you would also prefer such an intermediate
+stage for local repos, then setting the environment variable
+`GIT_REMOTE_HG_TEST_REMOTE` will also use a proxy repo clone for a local repo.
+
+As for the marks files, `marks-git` is created and used by `git-fast-export`
+and `git-fast-import` and contains a mapping from mark to commit hash, where a
+mark is essentially a plain number.  `marks-hg` similarly contains a (JSON) based
+mapping between such mark and hg revision hash.  Together they provide for a
+(consistent) view of the synchronization state of things.
+
+Upon a fetch, the helper uses the `marks-hg` file to decide what is already present
+and what not.  The required parts are then retrieved from Mercurial and turned
+into a `git-fast-import` stream as expected by `import` capability of
+https://www.kernel.org/pub/software/scm/git/docs/gitremote-helpers.html[gitremote-helpers(1)].
+
+Upon a push, the helper has specified the `push` capability in the new approach, and
+so git will provide a list of refspecs indicating what should go where.
+If the refspecs indicates a remote delete, it is performed appropriately the Mercurial way.
+If it is a regular push, then git-fast-export is invoked (using the existing `marks-git`)
+and the stream is processed and turned into Mercurial commits (along with bookmarks, etc).
+If the refspec specifies a `src:dest` rename, then the requested remote refname is tracked
+accordingly.  If a dry-run is requested, no remote is touched and no (marks) state of
+the run is retained.

--- a/doc/git-remote-hg.txt
+++ b/doc/git-remote-hg.txt
@@ -84,6 +84,16 @@ maintained not so visibly.  If that, however, would be preferred:
 % git config --global remote-hg.show-private-refs true
 --------------------------------------
 
+Use of shared marks files is the default in a new repo, but can also be enabled
+for an existing repo:
+
+--------------------------------------
+% git config --global remote-hg.shared-marks true
+--------------------------------------
+
+Note that one should perform a fetch from each remote to properly complete the
+conversion to shared marks files.
+
 NOTES
 -----
 
@@ -169,6 +179,14 @@ and `git-fast-import` and contains a mapping from mark to commit hash, where a
 mark is essentially a plain number.  `marks-hg` similarly contains a (JSON) based
 mapping between such mark and hg revision hash.  Together they provide for a
 (consistent) view of the synchronization state of things.
+
+When operating with shared-marks files, the `marks-git` and `marks-hg` files
+are shared among all repos.  As such, they are then found in the `.git/hg`
+directory (rather than a repo subdirectory).
+As there is really only one hg repository
+(the shared storage "union bag" in `.git/hg/.hg`), only 1 set of marks files
+should track the mapping between commit hash and revision hash.
+Each individual remote then only adds some metadata (e.g regarding heads).
 
 Upon a fetch, the helper uses the `marks-hg` file to decide what is already present
 and what not.  The required parts are then retrieved from Mercurial and turned

--- a/doc/git-remote-hg.txt
+++ b/doc/git-remote-hg.txt
@@ -84,13 +84,6 @@ maintained not so visibly.  If that, however, would be preferred:
 % git config --global remote-hg.show-private-refs true
 --------------------------------------
 
-By default, the refs/notes/hg are not updated upon push, though such can be
-enabled:
-
---------------------------------------
-% git config --global remote-hg.push-updates-notes true
---------------------------------------
-
 NOTES
 -----
 

--- a/doc/git-remote-hg.txt
+++ b/doc/git-remote-hg.txt
@@ -77,6 +77,20 @@ The default otherwise is simply `-M -C`.  See also e.g.
 https://www.kernel.org/pub/software/scm/git/docs/git-log.html[git-log(1) manpage]
 for more details on the options used to tweak this.
 
+As the old refs/hg/... are actually an implementation detail, they are now
+maintained not so visibly.  If that, however, would be preferred:
+
+--------------------------------------
+% git config --global remote-hg.show-private-refs true
+--------------------------------------
+
+By default, the refs/notes/hg are not updated upon push, though such can be
+enabled:
+
+--------------------------------------
+% git config --global remote-hg.push-updates-notes true
+--------------------------------------
+
 NOTES
 -----
 

--- a/doc/git-remote-hg.txt
+++ b/doc/git-remote-hg.txt
@@ -94,6 +94,14 @@ for an existing repo:
 Note that one should perform a fetch from each remote to properly complete the
 conversion to shared marks files.
 
+Mercurial name(s) (of a branch or bookmark) that are not a valid git refname,
+can be ignored by configuring a suitable regular expression, e.g. avoiding
+the invalid '~'
+
+--------------------------------------
+% git config --global remote-hg.ignore-name ~
+--------------------------------------
+
 NOTES
 -----
 

--- a/git-hg-helper
+++ b/git-hg-helper
@@ -4,6 +4,7 @@
 #
 
 from mercurial import hg, ui, commands, util
+from mercurial import context, subrepo
 
 import re
 import sys
@@ -174,6 +175,84 @@ class GitHgRepo:
             # if this one had it, we are done
             if srepo and rev in srepo and srepo[rev]:
                 return srepo
+
+    def rev_describe(self, rev):
+        result = self.run_cmd(['describe', rev]) or \
+            self.run_cmd(['describe', '--tags', rev]) or \
+            self.run_cmd(['describe', '--contains', rev]) or \
+            self.run_cmd(['describe', '--all', '--always', rev])
+        return result.strip()
+
+    class dictmemctx(context.memctx):
+
+        def __init__(self, repo, files):
+            p1, p2, data = repo[None], '0' * 40, ''
+            context.memctx.__init__(self, repo, (p1, p2),
+                data, files.keys(), self.getfilectx)
+            self.files = files
+
+        def __contains__(self, item):
+            return item in self.files
+
+        def getfilectx(self, repo, memctx, path):
+            is_exec = is_link = rename = False
+            if check_version(3, 1):
+                return context.memfilectx(repo, path, self.files[path],
+                        is_link, is_exec, rename)
+            else:
+                return context.memfilectx(path, self.files[path],
+                        is_link, is_exec, rename)
+
+    def read(self, relpath, rev=None):
+        rev = rev if rev else ':0'
+        obj = '%s:%s' % (rev, relpath)
+        # might complain bitterly to stderr if no subrepos so let's not show that
+        return self.run_cmd(['show', obj])
+
+    # see also subrepo.state
+    def state(self, remote='origin', rev=None):
+        """return a state dict, mapping subrepo paths configured in .hgsub
+        to tuple: (source from .hgsub, revision from .hgsubstate, kind
+        (key in types dict))
+        """
+
+        # obtain relevant files' content from specified revision
+        files = { }
+        for f in ('.hgsub', '.hgsubstate'):
+            files[f] = self.read(f)
+        log('state files for %s in revision %s:\n%s', remote, rev, files)
+
+        # wrap in a context and delegate to subrepo
+        # (rather than duplicating the admittedly simple parsing here)
+        repo = self.get_hg_repo(remote)
+        if not repo:
+            die('no hg repo for alias %s' % remote)
+        ctx = self.dictmemctx(repo, files)
+        state = subrepo.state(ctx, ui.ui())
+        log('obtained state %s', state)
+
+        # now filter on type and resolve relative urls
+        import posixpath
+        resolved = {}
+        for s in state:
+            src, rev, kind = state[s]
+            if not kind in ('hg', 'git'):
+                warn('skipping unsupported subrepo type %s' % kind)
+                continue
+            if not util.url(src).isabs():
+                parent = self.get_hg_repo_url(remote)
+                if not parent:
+                    die('could not determine repo url of %s' % remote)
+                parent = util.url(parent)
+                parent.path = posixpath.join(parent.path or '', src)
+                parent.path = posixpath.normpath(parent.path)
+                src = str(parent)
+            # translate to git view url
+            if kind == 'hg':
+                src = 'hg::' + src
+            resolved[s] = (src.strip(), rev or '', kind)
+        log('resolved state %s', resolved)
+        return resolved
 
 
 class SubCommand:
@@ -405,6 +484,304 @@ class MarksCommand(SubCommand):
                 gm.store()
 
 
+class SubRepoCommand(SubCommand):
+
+    def writestate(repo, state):
+        """rewrite .hgsubstate in (outer) repo with these subrepo states"""
+        lines = ['%s %s\n' % (state[s][1], s) for s in sorted(state)
+                                                    if state[s][1] != nullstate[1]]
+        repo.wwrite('.hgsubstate', ''.join(lines), '')
+
+    def argumentparser(self):
+        #usage = '%%(prog)s %s [options] <remote>...' % (self.subcommand)
+        # argparse.ArgumentParser(parents=[common])
+        # top-level
+        p = argparse.ArgumentParser(
+            formatter_class=argparse.RawDescriptionHelpFormatter)
+        p.add_argument('--quiet', '-q', action='store_true')
+        p.add_argument('--recursive', '-r', action='store_true',
+            help='recursive execution in each submodule')
+        p.add_argument('--remote', metavar='ALIAS', default='origin',
+            help='remote alias to use as base for relative url')
+        p.epilog = textwrap.dedent("""\
+        A group of (sub-)subcommands that aid in handling Mercurial subrepos
+        as managed by .hgsub and .hgsubstate.  The commands are (where applicable)
+        loosely modeled after the corresponding and similar git-submodule command,
+        though otherwise there is no relation whatsoever with the git-submodule system.
+        Each command supports recursive execution into subrepos of subrepos,
+        and the considered (top-level) repos can be restricted by a list of subrepo
+        paths as arguments.  For most commands, the state files are examined
+        in the parent repo's index.
+
+        Though depending on your workflow, the \'update\' command will likely
+        suffice, along with possibly an occasional \'upstate\'.
+        """)
+        # subparsers
+        sub = p.add_subparsers()
+        # common
+        common = argparse.ArgumentParser(add_help=False)
+        common.add_argument('paths', nargs=argparse.REMAINDER)
+        # update
+        p_update = sub.add_parser('update', parents=[common],
+            help='update subrepos to state as specified in parent repo')
+        p_update.set_defaults(func=self.cmd_update)
+        p_update.add_argument('--rebase', action='store_true',
+            help='rebase the subrepo current branch onto recorded superproject commit')
+        p_update.add_argument('--merge', action='store_true',
+            help='merge recorded superproject commit into the current branch of subrepo')
+        p_update.add_argument('--force', action='store_true',
+            help='throw away local changes when switching to a different commit')
+        p_update.epilog = textwrap.dedent("""\
+        Brings all subrepos in the state as specified by the parent repo.
+        If not yet present in the subpath, the subrepo is cloned from the URL
+        specified by the parent repo (resolving relative path wrt a parent repo URL).
+        If already present, and target state revision is ancestor of current HEAD,
+        no update is done.  Otherwise, a checkout to the required revision is done
+        (optionally forcibly so).  Alternatively, a rebase or merge is performed if
+        so requested by the corresponding option.
+        """)
+        # foreach
+        p_foreach = sub.add_parser('foreach',
+            help='evaluate shell command in each checked out subrepo')
+        p_foreach.set_defaults(func=self.cmd_foreach)
+        p_foreach.add_argument('command', help='shell command')
+        p_foreach.epilog = textwrap.dedent("""\
+        The command is executed in the subrepo directory and has access to
+        the variables $path, $toplevel, $sha1, $rev and $kind.
+        $path is the subrepo directory relative to the parent project.
+        $toplevel is the absolute path to the top-level of the parent project.
+        $rev is the state revision info as set in .hgsubstate whereas
+        $sha1 is the git commit corresponding to it (which may be identical
+        if subrepo is a git repo).  $kind is the type of subrepo, e.g. git or hg.
+        Unless given --quiet, the (recursively collected) submodule path is printed
+        before evaluating the command.  A non-zero return from the command in
+        any submodule causes the processing to terminate.
+        """)
+        # add state
+        p_upstate = sub.add_parser('upstate', parents=[common],
+            help='update .hgsubstate to current HEAD of subrepo')
+        p_upstate.set_defaults(func=self.cmd_upstate)
+        p_upstate.epilog = textwrap.dedent("""\
+        Rather than dealing with the index the .hgsubstate file is simply and only
+        edited to reflect the current HEAD of (all or selected) subrepos
+        (and any adding to index and committing is left to user's discretion).
+        """)
+        # status
+        p_status = sub.add_parser('status', parents=[common],
+            help='show the status of the subrepos')
+        p_status.add_argument('--cached', action='store_true',
+            help='show index .hgsubstate revision if != subrepo HEAD')
+        p_status.set_defaults(func=self.cmd_status)
+        p_status.epilog = textwrap.dedent("""\
+        This will print the SHA-1 of the currently checked out commit for each
+        subrepo, along with the subrepo path and the output of git describe for
+        the SHA-1.  Each SHA-1 will be prefixed with - if the submodule is not
+        yet set up (i.e. cloned) and + if the currently checked out submodule commit
+        does not match the SHA-1 found in the parent repo index state.
+        """)
+        # sync
+        p_sync = sub.add_parser('sync', parents=[common],
+            help='synchronize subrepo\'s remote URL configuration with parent configuration')
+        p_sync.set_defaults(func=self.cmd_sync)
+        p_sync.epilog = textwrap.dedent("""\
+        The subrepo's .git/config URL configuration is set to the value specified in
+        the parent's .hgstate (with relative path suitable resolved wrt parent project).
+        """)
+        return p
+
+    def git_hg_repo_try(self, path):
+        try:
+            return GitHgRepo(topdir=path)
+        except:
+            return None
+
+    def run_cmd(self, options, repo, *args, **kwargs):
+        # no output if quiet, otherwise show output by default
+        # unless the caller specified something explicitly
+        if hasattr(options, 'quiet') and options.quiet:
+            kwargs['stdout'] = os.devnull
+        elif 'stdout' not in kwargs:
+            kwargs['stdout'] = None
+        # show errors unless caller decide some way
+        if 'stderr' not in kwargs:
+            kwargs['stderr'] = None
+        repo.run_cmd(*args, **kwargs)
+
+    class subcontext(dict):
+        __getattr__= dict.__getitem__
+        __setattr__= dict.__setitem__
+        __delattr__= dict.__delitem__
+        def __init__(self, repo):
+            # recursion level
+            self.level = 0
+            # super repo object
+            self.repo = repo
+            # sub repo object (if any)
+            self.subrepo = None
+            # (recursively) collected path of subrepo
+            self.subpath = None
+            # relative path of subrepo wrt super repo
+            self.relpath = None
+
+    def do(self, options, args):
+        if args:
+            # all arguments are registered, so should not have leftover
+            # could be that main arguments were given to subcommands
+            warn('unparsed arguments: %s' % ' '.join(args))
+        log('running subcmd options %s, args %s', options, args)
+        # establish initial operation ctx
+        ctx = self.subcontext(self.githgrepo)
+        self.do_operation(options, args, ctx)
+
+    def do_operation(self, options, args, ctx):
+        log('running %s with options %s in context %s', \
+            options.func, options, ctx)
+        subrepos = ctx.repo.state(options.remote)
+        paths = subrepos.keys()
+        selabspaths = None
+        if ctx.level == 0 and hasattr(options, 'paths') and options.paths:
+            selabspaths = [ os.path.abspath(p) for p in options.paths ]
+        log('level %s selected paths %s', ctx.level, selabspaths)
+        for p in paths:
+            # prep context
+            ctx.relpath = p
+            ctx.subpath = os.path.join(ctx.repo.topdir, p)
+            # check if selected
+            abspath = os.path.abspath(ctx.subpath)
+            if selabspaths != None and abspath not in selabspaths:
+                log('skipping subrepo abspath %s' % abspath)
+                continue
+            ctx.subrepo = self.git_hg_repo_try(ctx.subpath)
+            ctx.state = subrepos[p]
+            # perform operation
+            log('exec for context %s', ctx)
+            options.func(options, args, ctx)
+            if not ctx.subrepo:
+                ctx.subrepo = self.git_hg_repo_try(ctx.subpath)
+            # prep recursion (only into git-hg subrepos)
+            if ctx.subrepo and options.recursive and ctx.state[2] == 'hg':
+                newctx = self.subcontext(ctx.subrepo)
+                newctx.level = ctx.level + 1
+                self.do_operation(options, args, newctx)
+
+    def get_git_commit(self, ctx):
+        src, rev, kind = ctx.state
+        if kind == 'hg':
+            gitcommit = ctx.subrepo.get_git_commit(rev)
+            if not gitcommit:
+                die('could not determine git commit for %s; a fetch may update notes' % rev)
+        else:
+            gitcommit = rev
+        return gitcommit
+
+    def cmd_upstate(self, options, args, ctx):
+        if not ctx.subrepo:
+            return
+        src, orig, kind = ctx.state
+        gitcommit = ctx.subrepo.rev_parse('HEAD')
+        if not gitcommit:
+            die('could not determine current HEAD state in %s' % ctx.subrepo.topdir)
+        rev = gitcommit
+        if kind == 'hg':
+            rev = ctx.subrepo.get_hg_rev(gitcommit)
+            if not rev:
+                die('could not determine hg changeset for commit %s' % gitcommit)
+        else:
+            rev = gitcommit
+        # obtain state from index
+        state_path = os.path.join(ctx.repo.topdir, '.hgsubstate')
+        # should have this, since we have subrepo (state) in the first place ...
+        if not os.path.exists(state_path):
+            die('no .hgsubstate found in repo %s' % ctx.repo.topdir)
+        if orig != rev:
+            short = ctx.subrepo.rev_parse(['--short', gitcommit])
+            print "Updating %s to %s [git %s]" % (ctx.subpath, rev, short)
+            # replace and update index
+            with open(state_path, 'r') as f:
+                state = f.read()
+            state = re.sub('.{40} %s' % (ctx.relpath), '%s %s' % (rev, ctx.relpath), state)
+            with open(state_path, 'wb') as f:
+                f.write(state)
+
+    def cmd_foreach(self, options, args, ctx):
+        if not ctx.subrepo:
+            return
+        if not options.quiet:
+            print 'Entering %s' % ctx.subpath
+            sys.stdout.flush()
+        newenv = os.environ.copy()
+        newenv['path'] = ctx.relpath
+        newenv['sha1'] = self.get_git_commit(ctx)
+        newenv['toplevel'] = os.path.abspath(ctx.repo.topdir)
+        newenv['rev'] = ctx.state[1]
+        newenv['kind'] = ctx.state[2]
+        proc = subprocess.Popen(options.command, shell=True, cwd=ctx.subpath, env=newenv)
+        proc.wait()
+        if proc.returncode != 0:
+            die('stopping at %s; script returned non-zero status' % ctx.subpath)
+
+    def cmd_update(self, options, args, ctx):
+        if not ctx.subrepo:
+            src, _, _ = ctx.state
+            self.run_cmd(options, ctx.repo, ['clone', src, ctx.subpath], cwd=None)
+            ctx.subrepo = self.git_hg_repo_try(ctx.subpath)
+            if not ctx.subrepo:
+                die('subrepo %s setup clone failed', ctx.subpath)
+            # force (detached) checkout of target commit following clone
+            cmd = [ 'checkout', '-q' ]
+        else:
+            self.run_cmd(options, ctx.subrepo, ['fetch', 'origin'], check=True)
+            cmd = []
+        # check if subrepo is up-to-date,
+        # i.e. if target commit is ancestor of HEAD
+        # (output never to be shown)
+        gitcommit = self.get_git_commit(ctx)
+        newrev = ctx.subrepo.run_cmd(['rev-list', gitcommit, '^HEAD']).strip()
+        if newrev and not cmd:
+            if options.force:
+                self.run_cmd(options, ctx.subrepo, ['reset', '--hard', 'HEAD'],
+                    check=True)
+            if options.rebase:
+                cmd = [ 'rebase' ]
+            elif options.merge:
+                cmd = [ 'merge' ]
+            else:
+                # we know about the detached consequences ... keep it a bit quiet
+                cmd = [ 'checkout', '-q' ]
+        if cmd:
+            cmd.append(gitcommit)
+            self.run_cmd(options, ctx.subrepo, cmd, check=True)
+
+    def cmd_status(self, options, args, ctx):
+        if not ctx.subrepo:
+            state = '-'
+            revname = ''
+            _, gitcommit, kind = ctx.state
+            if kind != 'git':
+                gitcommit += '[hg] '
+        else:
+            gitcommit = self.get_git_commit(ctx)
+            head = ctx.subrepo.rev_parse('HEAD')
+            if head == gitcommit:
+                state = ' '
+            else:
+                state = '+'
+                # option determines what to print
+                if not options.cached:
+                    gitcommit = head
+            revname = ctx.subrepo.rev_describe(gitcommit)
+            if revname:
+                revname = ' (%s)' % revname
+        print "%s%s %s%s" % (state, gitcommit, ctx.subpath, revname)
+
+    def cmd_sync(self, options, args, ctx):
+        if not ctx.subrepo:
+            return
+        src, _, _ = ctx.state
+        self.run_cmd(options, ctx.subrepo, \
+            ['config', 'remote.%s.url' % (options.remote), src])
+
+
 class RepoCommand(SubCommand):
 
     def argumentparser(self):
@@ -471,6 +848,7 @@ def get_subcommands():
         'git-rev': GitRevCommand,
         'repo': RepoCommand,
         'marks':  MarksCommand,
+        'sub': SubRepoCommand,
         'help' : HelpCommand
     }
     # add remote named subcommands
@@ -491,6 +869,7 @@ def do_usage():
     hg-rev  \t show hg revision corresponding to a git revision
     git-rev \t find git revision corresponding to a hg revision
     marks   \t perform maintenance on repo tracking marks
+    sub     \t manage subrepos
     repo    \t show local hg repo backing a remote
 
     If the subcommand is the name of a remote hg repo, then any remaining arguments
@@ -530,6 +909,23 @@ def init_logger():
         format='%(asctime)-15s %(levelname)s %(message)s')
     logger = logging.getLogger()
 
+def init_version():
+    global hg_version
+
+    try:
+        version, _, extra = util.version().partition('+')
+        version = list(int(e) for e in version.split('.'))
+        if extra:
+            version[1] += 1
+        hg_version = tuple(version)
+    except:
+        hg_version = None
+
+def check_version(*check):
+    if not hg_version:
+        return True
+    return hg_version >= check
+
 def main(argv):
     global subcommands
 
@@ -555,5 +951,6 @@ def main(argv):
         do_usage()
 
 init_logger()
+init_version()
 if __name__ == '__main__':
     sys.exit(main(sys.argv))

--- a/git-hg-helper
+++ b/git-hg-helper
@@ -36,6 +36,7 @@ def log(msg, *args):
 def import_sibling(mod, filename):
     import imp
     mydir = os.path.dirname(__file__)
+    sys.dont_write_bytecode = True
     return imp.load_source(mod, os.path.join(mydir, filename))
 
 class GitHgRepo:

--- a/git-hg-helper
+++ b/git-hg-helper
@@ -923,14 +923,14 @@ def check_version(*check):
 def main(argv):
     global subcommands
 
-    # init repo dir
-    # we will take over dir management ...
-    init_git(os.environ.pop('GIT_DIR', None))
-
     # as an alias, cwd is top dir, change again to original directory
     reldir = os.environ.get('GIT_PREFIX')
     if reldir:
         os.chdir(reldir)
+
+    # init repo dir
+    # we will take over dir management ...
+    init_git(os.environ.pop('GIT_DIR', None))
 
     subcommands = get_subcommands()
 

--- a/git-hg-helper
+++ b/git-hg-helper
@@ -33,6 +33,11 @@ def debug(msg, *args):
 def log(msg, *args):
     logger.log(logging.LOG, msg, *args)
 
+def import_sibling(mod, filename):
+    import imp
+    mydir = os.path.dirname(__file__)
+    return imp.load_source(mod, os.path.join(mydir, filename))
+
 class GitHgRepo:
 
     def __init__(self, topdir=None, gitdir=None):
@@ -119,9 +124,7 @@ class GitHgRepo:
         return self.run_cmd(['cat-file', '-p', ref])
 
     def get_git_commit(self, rev):
-        mydir = os.path.dirname(__file__)
-        import imp
-        remotehg = imp.load_source('remotehg', os.path.join(mydir, 'git-remote-hg'))
+        remotehg = import_sibling('remotehg', 'git-remote-hg')
         for r in self.get_hg_repos():
             try:
                 hgpath = os.path.join(self.gitdir, 'hg', r)
@@ -402,9 +405,7 @@ class GcCommand(SubCommand):
         dest.close()
 
     def do(self, options, args):
-        mydir = os.path.dirname(__file__)
-        import imp
-        remotehg = imp.load_source('remotehg', os.path.join(mydir, 'git-remote-hg'))
+        remotehg = import_sibling('remotehg', 'git-remote-hg')
 
         hg_repos = self.githgrepo.get_hg_repos()
         if not args:

--- a/git-hg-helper
+++ b/git-hg-helper
@@ -373,6 +373,8 @@ class GcCommand(SubCommand):
         usage = '%%(prog)s %s [options] <remote>...' % (self.subcommand)
         p = argparse.ArgumentParser(usage=usage, \
             formatter_class=argparse.RawDescriptionHelpFormatter)
+        p.add_argument('--check-hg', action='store_true',
+            help='also prune invalid hg revisions')
         p.add_argument('-n', '--dry-run', action='store_true',
             help='do not actually update any metadata files')
         p.epilog = textwrap.dedent("""\
@@ -415,7 +417,7 @@ class GcCommand(SubCommand):
             hgm = remotehg.Marks(os.path.join(hgpath, 'marks-hg'), None)
             print "Loading git marks ..."
             gm = GitMarks(os.path.join(hgpath, 'marks-git'))
-            repo = hg.repository(ui.ui(), hg_repos[remote])
+            repo = hg.repository(ui.ui(), hg_repos[remote]) if options.check_hg else None
             # git-gc may have dropped unreachable commits
             # (in particular due to multiple hg head cases)
             # need to drop those so git-fast-export or git-fast-import does not complain
@@ -436,6 +438,8 @@ class GcCommand(SubCommand):
             hg_rev_marks = {}
             git_rev_marks = {}
             for m in common_marks:
+                if repo and not hgm.rev_marks[m] in repo:
+                        continue
                 hg_rev_marks[m] = hgm.rev_marks[m]
                 git_rev_marks[m] = gm.rev_marks[m]
             # common marks will not not include any refs/notes/hg

--- a/git-hg-helper
+++ b/git-hg-helper
@@ -916,7 +916,7 @@ def init_version():
         version, _, extra = util.version().partition('+')
         version = list(int(e) for e in version.split('.'))
         if extra:
-            version[1] += 1
+            version[-1] += 1
         hg_version = tuple(version)
     except:
         hg_version = None

--- a/git-hg-helper
+++ b/git-hg-helper
@@ -13,6 +13,7 @@ import subprocess
 import argparse
 import textwrap
 import logging
+import threading
 
 # thanks go to git-remote-helper for some helper functions
 
@@ -59,9 +60,7 @@ class GitHgRepo:
     def identity(self):
         return '[%s|%s]' % (os.getcwd(), self.topdir)
 
-    # run a git cmd in repo dir, captures stdout and stderr by default
-    # override in kwargs if otherwise desired
-    def run_cmd(self, args, check=False, **kwargs):
+    def start_cmd(self, args, **kwargs):
         cmd = ['git'] + args
         popen_options = { 'cwd': self.topdir,
             'stdout': subprocess.PIPE, 'stderr': subprocess.PIPE }
@@ -69,6 +68,12 @@ class GitHgRepo:
         log('%s running cmd %s with options %s', self.identity(),
             cmd, popen_options)
         process = subprocess.Popen(cmd, **popen_options)
+        return process
+
+    # run a git cmd in repo dir, captures stdout and stderr by default
+    # override in kwargs if otherwise desired
+    def run_cmd(self, args, check=False, **kwargs):
+        process = self.start_cmd(args, **kwargs)
         output = process.communicate()[0]
         if check and process.returncode != 0:
             die('command failed: %s', ' '.join(cmd))
@@ -362,7 +367,7 @@ class GitRevCommand(SubCommand):
                 print gitcommit
 
 
-class MarksCommand(SubCommand):
+class GcCommand(SubCommand):
 
     def argumentparser(self):
         usage = '%%(prog)s %s [options] <remote>...' % (self.subcommand)
@@ -370,30 +375,29 @@ class MarksCommand(SubCommand):
             formatter_class=argparse.RawDescriptionHelpFormatter)
         p.add_argument('-n', '--dry-run', action='store_true',
             help='do not actually update any metadata files')
-        p.add_argument('--keep', metavar='REVID',
-            help='only retain ancestors of REVID (including) in \
-                  hg tracking metadata, akin to hg\'s strip')
         p.epilog = textwrap.dedent("""\
-        Performs checks on <remote>'s marks files and ensures these are consistent
+        Performs cleanup on <remote>'s marks files and ensures these are consistent
         (never affecting or touching any git repository objects or history).
         The marks files are considered consistent if they "join"
-        on the :mark number (with no dangling hg or git commit id on either side).
+        on the :mark number (along with a valid git commit id).
 
-        While fetching from an hg remote usually results in a sane state, there
-        are some cases where that might not suffice (or not even succeed in the first
-        place). Also, fetching will only ever add tracked metadata marks, whereas
-        sometimes forgetting about some state might be required for consistent state
-        recovery (e.g. a strip performed on a remote Mercurial repo). Executing this
-        command should allow a subsequent fetch to succeed and restore a sane state
-        quickly.  In particular, making good use of --keep following a strip allows
-        a subsequent fetch to recover quickly without extensive history processing.
-
-        Furthermore, since git-fast-import (used during fetch) also dumps
-        non-commit SHA-1 in the marks file, the latter can become pretty large.
-        It will reduce in size by either performing a push (git-fast-export only
-        dumps commit objects to marks file) or by running this helper command.
+        This command can be useful in following scenarios:
+        * following a git gc command;
+          this could prune objects and lead to (then) invalid commit ids in marks
+          (in which case git-fast-export or git-fast-import would complain bitterly).
+          Such pruning is more likely to happen with remote hg repos with multiple heads.
+        * cleaning marks-git of a fetch-only remote;
+          git-fast-import (used during fetch) also dumps non-commit SHA-1 in the marks file,
+          so the latter can become pretty large. It will reduce in size either by a push
+          (git-fast-export only dumps commit objects) or by running this helper command.
         """)
         return p
+
+    def print_commits(self, gm, dest):
+        for c in gm.marks.keys():
+            dest.write(c + '\n')
+        dest.flush()
+        dest.close()
 
     def do(self, options, args):
         mydir = os.path.dirname(__file__)
@@ -407,31 +411,37 @@ class MarksCommand(SubCommand):
             if not remote in hg_repos:
                 self.usage('%s is not a valid hg remote' % (remote))
             hgpath = os.path.join(self.githgrepo.gitdir, 'hg', remote)
+            print "Loading hg marks ..."
             hgm = remotehg.Marks(os.path.join(hgpath, 'marks-hg'), None)
+            print "Loading git marks ..."
             gm = GitMarks(os.path.join(hgpath, 'marks-git'))
             repo = hg.repository(ui.ui(), hg_repos[remote])
-            ctx = ctxrev = None
-            if options.keep != None:
-                strip = options.keep
-                if strip in repo and repo[strip]:
-                    ctx = repo[strip]
-                    ctxrev = ctx.rev()
-                if not ctxrev >= 0:
-                    self.usage('revision %s not found in repository %s' % (strip, repo.root))
+            # git-gc may have dropped unreachable commits
+            # (in particular due to multiple hg head cases)
+            # need to drop those so git-fast-export or git-fast-import does not complain
+            print "Performing garbage collection on git commits ..."
+            process = self.githgrepo.start_cmd(['cat-file', '--batch-check'], \
+                stdin=subprocess.PIPE)
+            thread = threading.Thread(target=self.print_commits, args=(gm, process.stdin))
+            thread.start()
+            git_marks = set({})
+            for l in process.stdout:
+                sp = l.strip().split(' ', 2)
+                if sp[1] == 'commit':
+                    git_marks.add(gm.from_rev(sp[0]))
+            thread.join()
             # reduce down to marks that are common to both
-            common_marks = set(hgm.rev_marks.keys()).intersection(gm.rev_marks.keys())
+            print "Computing marks intersection ..."
+            common_marks = set(hgm.rev_marks.keys()).intersection(git_marks)
             hg_rev_marks = {}
             git_rev_marks = {}
             for m in common_marks:
-                rev = hgm.rev_marks[m]
-                # also check if still around in repo
-                if rev in repo and \
-                        not (ctxrev != None and repo[rev].rev() > ctxrev):
-                    hg_rev_marks[m] = hgm.rev_marks[m]
-                    git_rev_marks[m] = gm.rev_marks[m]
+                hg_rev_marks[m] = hgm.rev_marks[m]
+                git_rev_marks[m] = gm.rev_marks[m]
             # common marks will not not include any refs/notes/hg
             # let's not discard those casually, though they are not vital
-            revlist = subprocess.Popen(['git', 'rev-list', 'refs/notes/hg'], stdout=subprocess.PIPE)
+            print "Including notes commits ..."
+            revlist = self.githgrepo.start_cmd(['rev-list', 'refs/notes/hg'])
             for l in revlist.stdout.readlines():
                 c = l.strip()
                 m = gm.marks.get(c, 0)
@@ -445,38 +455,18 @@ class MarksCommand(SubCommand):
                 print "Trimmed hg marks from #%d down to #%d" % (len(hgm.rev_marks), len(hg_rev_marks))
             if len(gm.rev_marks) != len(git_rev_marks):
                 print "Trimmed git marks from #%d down to #%d" % (len(gm.rev_marks), len(git_rev_marks))
-            # make hg tips as consistent as possible
-            for b in hgm.tips:
-                tip = hgm.tips[b]
-                if tip not in repo or not repo[tip]:
-                    if not ctx:
-                        print "Could not determine safe value for tip of %s (rev %s)" % (b, tip)
-                        print "Please use --strip to provide fallback value."
-                        return
-                    else:
-                        # basically only the revision number is used by a fetch
-                        tip = ctx.hex()
-                else:
-                    hgrevs = set(hg_rev_marks.values())
-                    while True:
-                        if tip in hgrevs:
-                            break
-                        parent = repo[tip].parents()[0].hex()
-                        if parent == tip:
-                            break
-                        tip = parent
-                if hgm.tips[b] != tip:
-                    hgm.tips[b] = tip
-                    print "Updated tip of %s to %s" % (b, tip)
+            # marks-hg tips irrelevant nowadays
             # now update and store
             if not options.dry_run:
                 # hg marks
+                print "Writing hg marks ..."
                 hgm.rev_marks = hg_rev_marks
                 hgm.marks = {}
                 for mark, rev in hg_rev_marks.iteritems():
                     hgm.marks[rev] = mark
                 hgm.store()
                 # git marks
+                print "Writing git marks ..."
                 gm.rev_marks = git_rev_marks
                 gm.marks = {}
                 for mark, rev in git_rev_marks.iteritems():
@@ -847,7 +837,7 @@ def get_subcommands():
         'hg-rev': HgRevCommand,
         'git-rev': GitRevCommand,
         'repo': RepoCommand,
-        'marks':  MarksCommand,
+        'gc':  GcCommand,
         'sub': SubRepoCommand,
         'help' : HelpCommand
     }
@@ -868,7 +858,7 @@ def do_usage():
 
     hg-rev  \t show hg revision corresponding to a git revision
     git-rev \t find git revision corresponding to a hg revision
-    marks   \t perform maintenance on repo tracking marks
+    gc      \t perform maintenance and consistency cleanup on repo tracking marks
     sub     \t manage subrepos
     repo    \t show local hg repo backing a remote
 

--- a/git-hg-helper
+++ b/git-hg-helper
@@ -128,7 +128,7 @@ class GitHgRepo:
         remotehg = import_sibling('remotehg', 'git-remote-hg')
         for r in self.get_hg_repos():
             try:
-                hgpath = os.path.join(self.gitdir, 'hg', r)
+                hgpath = remotehg.select_marks_dir(r, self.gitdir, False)
                 m = remotehg.Marks(os.path.join(hgpath, 'marks-hg'), None)
                 mark = m.from_rev(rev)
                 m = GitMarks(os.path.join(hgpath, 'marks-git'))
@@ -150,6 +150,9 @@ class GitHgRepo:
             for r in repos:
                 # skip the shared repo
                 if r == '.hg':
+                    continue
+                # only dirs
+                if not os.path.isdir(os.path.join(shared_path, r)):
                     continue
                 local_path = os.path.join(shared_path, r, 'clone')
                 local_hg = os.path.join(local_path, '.hg')
@@ -415,7 +418,7 @@ class GcCommand(SubCommand):
         for remote in args:
             if not remote in hg_repos:
                 self.usage('%s is not a valid hg remote' % (remote))
-            hgpath = os.path.join(self.githgrepo.gitdir, 'hg', remote)
+            hgpath = remotehg.select_marks_dir(remote, self.githgrepo.gitdir, False)
             print "Loading hg marks ..."
             hgm = remotehg.Marks(os.path.join(hgpath, 'marks-hg'), None)
             print "Loading git marks ..."

--- a/git-hg-helper
+++ b/git-hg-helper
@@ -239,7 +239,12 @@ class GitHgRepo:
         if not repo:
             die('no hg repo for alias %s' % remote)
         ctx = self.dictmemctx(repo, files)
-        state = subrepo.state(ctx, ui.ui())
+        # helpers moved around 4.6
+        if hasattr(subrepo, 'state'):
+          state = subrepo.state(ctx, ui.ui())
+        else:
+          from mercurial import subrepoutil
+          state = subrepoutil.state(ctx, ui.ui())
         log('obtained state %s', state)
 
         # now filter on type and resolve relative urls

--- a/git-hg-helper
+++ b/git-hg-helper
@@ -203,18 +203,16 @@ class GitHgRepo:
             context.memctx.__init__(self, repo, (p1, p2),
                 data, files.keys(), self.getfilectx)
             self.files = files
+            self.remotehg = import_sibling('remotehg', 'git-remote-hg')
+            self.remotehg.hg_version = hg_version
 
         def __contains__(self, item):
             return item in self.files
 
         def getfilectx(self, repo, memctx, path):
             is_exec = is_link = rename = False
-            if check_version(3, 1):
-                return context.memfilectx(repo, path, self.files[path],
-                        is_link, is_exec, rename)
-            else:
-                return context.memfilectx(path, self.files[path],
-                        is_link, is_exec, rename)
+            return self.remotehg.make_memfilectx(repo, memctx, path, self.files[path],
+                is_link, is_exec, rename)
 
     def read(self, relpath, rev=None):
         rev = rev if rev else ':0'

--- a/git-hg-helper
+++ b/git-hg-helper
@@ -1,0 +1,559 @@
+#!/usr/bin/env python2
+#
+# Copyright (c) 2016 Mark Nauwelaerts
+#
+
+from mercurial import hg, ui, commands, util
+
+import re
+import sys
+import os
+import subprocess
+import argparse
+import textwrap
+import logging
+
+# thanks go to git-remote-helper for some helper functions
+
+def die(msg, *args):
+    sys.stderr.write('ERROR: %s\n' % (msg % args))
+    sys.exit(1)
+
+def warn(msg, *args):
+    sys.stderr.write('WARNING: %s\n' % (msg % args))
+
+def info(msg, *args):
+    logger.info(msg, *args)
+
+def debug(msg, *args):
+    logger.debug(msg, *args)
+
+def log(msg, *args):
+    logger.log(logging.LOG, msg, *args)
+
+class GitHgRepo:
+
+    def __init__(self, topdir=None, gitdir=None):
+        if gitdir != None:
+            self.gitdir = gitdir
+            self.topdir = os.path.join(gitdir, '..') # will have to do
+        else:
+            self.topdir = None
+            if not topdir:
+                topdir = self.run_cmd(['rev-parse', '--show-cdup']).strip()
+                if not topdir:
+                    if not os.path.exists('.git'):
+                        # now we lost where we are
+                        raise Exception('failed to determine topdir')
+                    topdir = '.'
+            self.topdir = topdir
+            self.gitdir = self.run_cmd(['rev-parse', '--git-dir']).strip()
+            if not self.gitdir:
+                raise Exception('failed to determine gitdir')
+            # the above was run in topdir
+            if not os.path.isabs(self.gitdir):
+                self.gitdir = os.path.join(self.topdir, self.gitdir)
+        self.hg_repos = {}
+
+    def identity(self):
+        return '[%s|%s]' % (os.getcwd(), self.topdir)
+
+    # run a git cmd in repo dir, captures stdout and stderr by default
+    # override in kwargs if otherwise desired
+    def run_cmd(self, args, check=False, **kwargs):
+        cmd = ['git'] + args
+        popen_options = { 'cwd': self.topdir,
+            'stdout': subprocess.PIPE, 'stderr': subprocess.PIPE }
+        popen_options.update(kwargs)
+        log('%s running cmd %s with options %s', self.identity(),
+            cmd, popen_options)
+        process = subprocess.Popen(cmd, **popen_options)
+        output = process.communicate()[0]
+        if check and process.returncode != 0:
+            die('command failed: %s', ' '.join(cmd))
+        return output
+
+    def get_config(self, config, getall=False):
+        get = { True : '--get-all', False: '--get' }
+        cmd = ['git', 'config', get[getall] , config]
+        return self.run_cmd(['config', get[getall] , config], stderr=None)
+
+    def get_config_bool(self, config, default=False):
+        value = self.get_config(config).rstrip('\n')
+        if value == "true":
+            return True
+        elif value == "false":
+            return False
+        else:
+            return default
+
+    def get_hg_repo_url(self, remote):
+        url = self.get_config('remote.%s.url' % (remote))
+        if url and url[0:4] == 'hg::':
+            url = url[4:].strip()
+        else:
+            url = None
+        return url
+
+    def get_hg_rev(self, commit):
+        hgrev = self.run_cmd(['notes', '--ref', 'refs/notes/hg', 'show', commit])
+        return hgrev
+
+    def rev_parse(self, ref):
+        args = [ref] if not isinstance(ref, list) else ref
+        args[0:0] = ['rev-parse', '--verify', '-q']
+        return self.run_cmd(args).strip()
+
+    def update_ref(self, ref, value):
+        self.run_cmd(['update-ref', '-m', 'update by helper', ref, value])
+        # let's check it happened
+        return git_rev_parse(ref) == git_rev_parse(value)
+
+    def cat_file(self,  ref):
+        return self.run_cmd(['cat-file', '-p', ref])
+
+    def get_git_commit(self, rev):
+        mydir = os.path.dirname(__file__)
+        import imp
+        remotehg = imp.load_source('remotehg', os.path.join(mydir, 'git-remote-hg'))
+        for r in self.get_hg_repos():
+            try:
+                hgpath = os.path.join(self.gitdir, 'hg', r)
+                m = remotehg.Marks(os.path.join(hgpath, 'marks-hg'), None)
+                mark = m.from_rev(rev)
+                m = GitMarks(os.path.join(hgpath, 'marks-git'))
+                return m.to_rev(mark)
+            except:
+                pass
+
+    # returns dict: (alias: local hg repo dir)
+    def get_hg_repos(self):
+        # minor caching
+        if self.hg_repos:
+            return self.hg_repos
+
+        # check any local hg repo to see if rev is in there
+        shared_path = os.path.join(self.gitdir, 'hg')
+        hg_path = os.path.join(shared_path, '.hg')
+        if os.path.exists(shared_path):
+            repos = os.listdir(shared_path)
+            for r in repos:
+                # skip the shared repo
+                if r == '.hg':
+                    continue
+                local_path = os.path.join(shared_path, r, 'clone')
+                local_hg = os.path.join(local_path, '.hg')
+                if not os.path.exists(local_hg):
+                    # could be a local repo without proxy, fetch url
+                    local_path = self.get_hg_repo_url(r)
+                    if not local_path:
+                        warn('failed to find local hg for remote %s', r)
+                        continue
+                else:
+                    # make sure the shared path is always up-to-date
+                    util.writefile(os.path.join(local_hg, 'sharedpath'), hg_path)
+                self.hg_repos[r] = os.path.join(local_path)
+
+        log('%s determined hg_repos %s', self.identity(), self.hg_repos)
+        return self.hg_repos
+
+    # returns hg repo object
+    def get_hg_repo(self, r):
+        repos = self.get_hg_repos()
+        if r in repos:
+            local_path = repos[r]
+            hushui = ui.ui()
+            hushui.setconfig('ui', 'interactive', 'off')
+            hushui.fout = open(os.devnull, 'w')
+            return hg.repository(hushui, local_path)
+
+    def find_hg_repo(self, rev):
+        repos = self.get_hg_repos()
+        for r in repos:
+            srepo = self.get_hg_repo(r)
+            # if this one had it, we are done
+            if srepo and rev in srepo and srepo[rev]:
+                return srepo
+
+
+class SubCommand:
+
+    def __init__(self, subcmdname, githgrepo):
+        self.subcommand = subcmdname
+        self.githgrepo = githgrepo
+        self.argparser = self.argumentparser()
+
+    def argumentparser(self):
+        return argparse.ArgumentParser()
+
+    def get_remote(self, args):
+        if len(args):
+            return (args[0], args[1:])
+        else:
+            self.usage('missing argument: <remote-alias>')
+
+    def get_remote_url_hg(self, remote):
+        url = self.githgrepo.get_hg_repo_url(remote)
+        if not url:
+            self.usage('%s is not a remote hg repository' % (remote))
+        return url
+
+    def execute(self, args):
+        (self.options, self.args) = self.argparser.parse_known_args(args)
+        self.do(self.options, self.args)
+
+    def usage(self, msg):
+        if msg:
+            self.argparser.error(msg)
+        else:
+            self.argparser.print_usage(sys.stderr)
+            sys.exit(2)
+
+    def do(self, options, args):
+        pass
+
+
+class HgRevCommand(SubCommand):
+
+    def argumentparser(self):
+        usage = '%%(prog)s %s [options] <commit-ish>' % (self.subcommand)
+        p = argparse.ArgumentParser(usage=usage)
+        p.epilog = textwrap.dedent("""\
+        Determines the hg revision corresponding to <commit-ish>.
+        """)
+        return p
+
+    def do(self, options, args):
+        if len(args):
+            hgrev = self.githgrepo.get_hg_rev(args[0])
+            if hgrev:
+                print hgrev
+
+
+class GitMarks:
+
+    def __init__(self, path):
+      self.path = path
+      self.clear()
+      self.load()
+
+    def clear(self):
+        self.marks = {}
+        self.rev_marks = {}
+
+    def load(self):
+        if not os.path.exists(self.path):
+            return
+
+        for l in file(self.path):
+            m, c = l.strip().split(' ', 2)
+            m = int(m[1:])
+            self.marks[c] = m
+            self.rev_marks[m] = c
+
+    def store(self):
+        marks = self.rev_marks.keys()
+        marks.sort()
+        with open(self.path, 'w') as f:
+            for m in marks:
+                f.write(':%d %s\n' % (m, self.rev_marks[m]))
+
+    def from_rev(self, rev):
+        return self.marks[rev]
+
+    def to_rev(self, mark):
+        return str(self.rev_marks[mark])
+
+
+class GitRevCommand(SubCommand):
+
+    def argumentparser(self):
+        usage = '%%(prog)s %s [options] <revision>' % (self.subcommand)
+        p = argparse.ArgumentParser(usage=usage)
+        p.epilog = textwrap.dedent("""\
+        Determines the git commit id corresponding to hg <revision>.
+        """)
+        return p
+
+    def do(self, options, args):
+        if len(args):
+            rev = args[0]
+            gitcommit = self.githgrepo.get_git_commit(rev)
+            if gitcommit:
+                print gitcommit
+
+
+class MarksCommand(SubCommand):
+
+    def argumentparser(self):
+        usage = '%%(prog)s %s [options] <remote>...' % (self.subcommand)
+        p = argparse.ArgumentParser(usage=usage, \
+            formatter_class=argparse.RawDescriptionHelpFormatter)
+        p.add_argument('-n', '--dry-run', action='store_true',
+            help='do not actually update any metadata files')
+        p.add_argument('--keep', metavar='REVID',
+            help='only retain ancestors of REVID (including) in \
+                  hg tracking metadata, akin to hg\'s strip')
+        p.epilog = textwrap.dedent("""\
+        Performs checks on <remote>'s marks files and ensures these are consistent
+        (never affecting or touching any git repository objects or history).
+        The marks files are considered consistent if they "join"
+        on the :mark number (with no dangling hg or git commit id on either side).
+
+        While fetching from an hg remote usually results in a sane state, there
+        are some cases where that might not suffice (or not even succeed in the first
+        place). Also, fetching will only ever add tracked metadata marks, whereas
+        sometimes forgetting about some state might be required for consistent state
+        recovery (e.g. a strip performed on a remote Mercurial repo). Executing this
+        command should allow a subsequent fetch to succeed and restore a sane state
+        quickly.  In particular, making good use of --keep following a strip allows
+        a subsequent fetch to recover quickly without extensive history processing.
+
+        Furthermore, since git-fast-import (used during fetch) also dumps
+        non-commit SHA-1 in the marks file, the latter can become pretty large.
+        It will reduce in size by either performing a push (git-fast-export only
+        dumps commit objects to marks file) or by running this helper command.
+        """)
+        return p
+
+    def do(self, options, args):
+        mydir = os.path.dirname(__file__)
+        import imp
+        remotehg = imp.load_source('remotehg', os.path.join(mydir, 'git-remote-hg'))
+
+        hg_repos = self.githgrepo.get_hg_repos()
+        if not args:
+            self.usage('no remote specified')
+        for remote in args:
+            if not remote in hg_repos:
+                self.usage('%s is not a valid hg remote' % (remote))
+            hgpath = os.path.join(self.githgrepo.gitdir, 'hg', remote)
+            hgm = remotehg.Marks(os.path.join(hgpath, 'marks-hg'), None)
+            gm = GitMarks(os.path.join(hgpath, 'marks-git'))
+            repo = hg.repository(ui.ui(), hg_repos[remote])
+            ctx = ctxrev = None
+            if options.keep != None:
+                strip = options.keep
+                if strip in repo and repo[strip]:
+                    ctx = repo[strip]
+                    ctxrev = ctx.rev()
+                if not ctxrev >= 0:
+                    self.usage('revision %s not found in repository %s' % (strip, repo.root))
+            # reduce down to marks that are common to both
+            common_marks = set(hgm.rev_marks.keys()).intersection(gm.rev_marks.keys())
+            hg_rev_marks = {}
+            git_rev_marks = {}
+            for m in common_marks:
+                rev = hgm.rev_marks[m]
+                # also check if still around in repo
+                if rev in repo and \
+                        not (ctxrev != None and repo[rev].rev() > ctxrev):
+                    hg_rev_marks[m] = hgm.rev_marks[m]
+                    git_rev_marks[m] = gm.rev_marks[m]
+            # common marks will not not include any refs/notes/hg
+            # let's not discard those casually, though they are not vital
+            revlist = subprocess.Popen(['git', 'rev-list', 'refs/notes/hg'], stdout=subprocess.PIPE)
+            for l in revlist.stdout.readlines():
+                c = l.strip()
+                m = gm.marks.get(c, 0)
+                if m:
+                    git_rev_marks[m] = c
+            # also save last-note mark
+            if hgm.last_note:
+                git_rev_marks[hgm.last_note] = gm.rev_marks[hgm.last_note]
+            # some status report
+            if len(hgm.rev_marks) != len(hg_rev_marks):
+                print "Trimmed hg marks from #%d down to #%d" % (len(hgm.rev_marks), len(hg_rev_marks))
+            if len(gm.rev_marks) != len(git_rev_marks):
+                print "Trimmed git marks from #%d down to #%d" % (len(gm.rev_marks), len(git_rev_marks))
+            # make hg tips as consistent as possible
+            for b in hgm.tips:
+                tip = hgm.tips[b]
+                if tip not in repo or not repo[tip]:
+                    if not ctx:
+                        print "Could not determine safe value for tip of %s (rev %s)" % (b, tip)
+                        print "Please use --strip to provide fallback value."
+                        return
+                    else:
+                        # basically only the revision number is used by a fetch
+                        tip = ctx.hex()
+                else:
+                    hgrevs = set(hg_rev_marks.values())
+                    while True:
+                        if tip in hgrevs:
+                            break
+                        parent = repo[tip].parents()[0].hex()
+                        if parent == tip:
+                            break
+                        tip = parent
+                if hgm.tips[b] != tip:
+                    hgm.tips[b] = tip
+                    print "Updated tip of %s to %s" % (b, tip)
+            # now update and store
+            if not options.dry_run:
+                # hg marks
+                hgm.rev_marks = hg_rev_marks
+                hgm.marks = {}
+                for mark, rev in hg_rev_marks.iteritems():
+                    hgm.marks[rev] = mark
+                hgm.store()
+                # git marks
+                gm.rev_marks = git_rev_marks
+                gm.marks = {}
+                for mark, rev in git_rev_marks.iteritems():
+                    gm.marks[rev] = mark
+                gm.store()
+
+
+class RepoCommand(SubCommand):
+
+    def argumentparser(self):
+        usage = '%%(prog)s %s [options] <remote>...' % (self.subcommand)
+        p = argparse.ArgumentParser(usage=usage)
+        p.epilog = textwrap.dedent("""\
+        Determines the local hg repository of <remote>.
+        This can either be a separate and independent local hg repository
+        or a local proxy repo (within the .git directory).
+        """)
+        return p
+
+    def do(self, options, args):
+        (remote, args) = self.get_remote(args)
+        repos = self.githgrepo.get_hg_repos()
+        if remote in repos:
+            print repos[remote].rstrip('/')
+
+
+class HgCommand(SubCommand):
+
+    def argumentparser(self):
+        usage = '%%(prog)s %s <hg-command>...' % (self.subcommand)
+        p = argparse.ArgumentParser(usage=usage)
+        hgdir = self.githgrepo.get_hg_repos()[self.subcommand]
+        p.epilog = textwrap.dedent("""\
+        Executes <hg-command> on the backing repository of %s (%s)
+        (by supplying it with the standard -R option).
+        """ % (self.subcommand, hgdir))
+        return p
+
+    def do(self, options, args):
+        # subcommand name is already a known valid alias of hg repo
+        remote = self.subcommand
+        repos = self.githgrepo.get_hg_repos()
+        if len(args) and remote in repos:
+            if args[0].find('hg') < 0:
+                args.insert(0, 'hg')
+            args[1:1] = ['-R', repos[remote]]
+            p = subprocess.Popen(args, stdout=None)
+            p.wait()
+        else:
+            if len(args):
+                self.usage('invalid repo: %s' % remote)
+            else:
+                self.usage('missing command')
+
+
+class HelpCommand(SubCommand):
+
+    def do(self, options, args):
+        if len(args):
+            cmd = args[0]
+            if cmd in subcommands:
+                p = subcommands[cmd].argumentparser()
+                p.print_help(sys.stderr)
+                return
+        do_usage()
+
+
+def get_subcommands():
+    commands = {
+        'hg-rev': HgRevCommand,
+        'git-rev': GitRevCommand,
+        'repo': RepoCommand,
+        'marks':  MarksCommand,
+        'help' : HelpCommand
+    }
+    # add remote named subcommands
+    repos = githgrepo.get_hg_repos()
+    for r in repos:
+        if not r in commands:
+            commands[r] = HgCommand
+    # now turn into instances
+    for c in commands:
+        commands[c] = commands[c](c, githgrepo)
+    return commands
+
+
+def do_usage():
+    usage = textwrap.dedent("""
+    git-hg-helper subcommands:
+
+    hg-rev  \t show hg revision corresponding to a git revision
+    git-rev \t find git revision corresponding to a hg revision
+    marks   \t perform maintenance on repo tracking marks
+    repo    \t show local hg repo backing a remote
+
+    If the subcommand is the name of a remote hg repo, then any remaining arguments
+    are considered a "hg command", e.g. hg heads, or thg, and it is then executed
+    with -R set appropriately to the local hg repo backing the specified remote.
+    Do note, however, that the local proxy repos are not maintained as exact mirrors
+    of their respective remote, and also use shared storage.  As such, depending
+    on the command, the result may not be exactly as could otherwise be expected
+    (e.g. might involve more heads, etc).
+
+    Available hg remotes:
+    """)
+    for r in githgrepo.get_hg_repos():
+        usage += '\t%s\n' % (r)
+    usage += '\n'
+    sys.stderr.write(usage)
+    sys.stderr.flush()
+    sys.exit(2)
+
+def init_git(gitdir=None):
+    global githgrepo
+
+    try:
+        githgrepo = GitHgRepo(gitdir=gitdir)
+    except Exception, e:
+        die(str(e))
+
+def init_logger():
+    global logger
+
+    # setup logging
+    logging.LOG = 5
+    logging.addLevelName(logging.LOG, 'LOG')
+    envlevel = os.environ.get('GIT_HG_HELPER_DEBUG', 'WARN')
+    loglevel = logging.getLevelName(envlevel)
+    logging.basicConfig(level=loglevel, \
+        format='%(asctime)-15s %(levelname)s %(message)s')
+    logger = logging.getLogger()
+
+def main(argv):
+    global subcommands
+
+    # init repo dir
+    # we will take over dir management ...
+    init_git(os.environ.pop('GIT_DIR', None))
+
+    # as an alias, cwd is top dir, change again to original directory
+    reldir = os.environ.get('GIT_PREFIX')
+    if reldir:
+        os.chdir(reldir)
+
+    subcommands = get_subcommands()
+
+    cmd = ''
+    if len(argv) > 1:
+        cmd = argv[1]
+    argv = argv[2:]
+    if cmd in subcommands:
+        c = subcommands[cmd]
+        c.execute(argv)
+    else:
+        do_usage()
+
+init_logger()
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/git-hg-helper
+++ b/git-hg-helper
@@ -161,7 +161,8 @@ class GitHgRepo:
                         continue
                 else:
                     # make sure the shared path is always up-to-date
-                    util.writefile(os.path.join(local_hg, 'sharedpath'), hg_path)
+                    util.writefile(os.path.join(local_hg, 'sharedpath'),
+                        os.path.abspath(hg_path))
                 self.hg_repos[r] = os.path.join(local_path)
 
         log('%s determined hg_repos %s', self.identity(), self.hg_repos)

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -581,7 +581,7 @@ def export_ref(repo, name, kind, head):
             if extra_msg:
                 desc += '\n--HG--\n' + extra_msg
 
-        if len(parents) == 0 and rev:
+        if len(parents) == 0:
             print 'reset %s/%s' % (prefix, ename)
 
         modified_final = export_files(c.filectx(f) for f in modified)

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -14,7 +14,7 @@
 # "$GIT_DIR/hg/origin/clone/.hg/".
 
 from mercurial import hg, ui, bookmarks, context, encoding
-from mercurial import node, error, extensions, discovery, util
+from mercurial import node, error, extensions, discovery, util, scmutil
 from mercurial import changegroup
 
 import re
@@ -629,7 +629,7 @@ def export_ref(repo, name, kind, head):
         notes.update(pending_revs)
 
 def export_tag(repo, tag):
-    export_ref(repo, tag, 'tags', repo[hgref(tag)])
+    export_ref(repo, tag, 'tags', scmutil.revsingle(repo, hgref(tag)))
 
 def export_bookmark(repo, bmark):
     head = bmarks[hgref(bmark)]

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -1121,7 +1121,10 @@ def checkheads_bmark(repo, ref, ctx, force):
         print "error %s unknown" % ref
         return False
 
-    if not repo.changelog.descendant(ctx_old.rev(), ctx_new.rev()):
+    # replaced around Mercurial 4.7
+    isancestor = repo.changelog.isancestorrev if hasattr(repo.changelog, 'isancestorrev') \
+        else repo.changelog.descendant
+    if not isancestor(ctx_old.rev(), ctx_new.rev()):
         if force:
             print "ok %s forced update" % ref
         else:

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -1175,7 +1175,11 @@ def push_unsafe(repo, remote, p_revs, force):
         return None
 
     if check_version(4, 0):
-        cg = changegroup.getlocalchangegroup(repo, 'push', outgoing)
+        if hasattr(changegroup, 'getlocalchangegroup'):
+            cg = changegroup.getlocalchangegroup(repo, 'push', outgoing)
+        else:
+            # as of about version 4.4
+            cg = changegroup.makechangegroup(repo, outgoing, '01', 'push')
     elif check_version(3, 2):
         cg = changegroup.getchangegroup(repo, 'push', heads=list(p_revs), common=common)
     elif check_version(3, 0):

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -1078,7 +1078,7 @@ def write_tag(repo, tag, node, msg, author):
 
     return (tagnode, branch)
 
-def checkheads_bmark(repo, ref, ctx):
+def checkheads_bmark(repo, ref, ctx, force):
     bmark = ref[len('refs/heads/'):]
     if bmark not in bmarks:
         # new bmark
@@ -1092,7 +1092,7 @@ def checkheads_bmark(repo, ref, ctx):
         return False
 
     if not repo.changelog.descendant(ctx_old.rev(), ctx_new.rev()):
-        if force_push:
+        if force:
             print "ok %s forced update" % ref
         else:
             print "error %s non-fast forward" % ref
@@ -1100,7 +1100,7 @@ def checkheads_bmark(repo, ref, ctx):
 
     return True
 
-def checkheads(repo, remote, p_revs):
+def checkheads(repo, remote, p_revs, force):
 
     remotemap = remote.branchmap()
     if not remotemap:
@@ -1118,7 +1118,7 @@ def checkheads(repo, remote, p_revs):
             continue
         if not ref.startswith('refs/heads/branches'):
             if ref.startswith('refs/heads/'):
-                if not checkheads_bmark(repo, ref, ctx):
+                if not checkheads_bmark(repo, ref, ctx, force):
                     ret = False
 
             # only check branches
@@ -1144,7 +1144,7 @@ def checkheads(repo, remote, p_revs):
 
             node = repo.changelog.node(rev)
             ref = p_revs[node]
-            if force_push:
+            if force:
                 print "ok %s forced update" % ref
             else:
                 print "error %s non-fast forward" % ref
@@ -1152,18 +1152,13 @@ def checkheads(repo, remote, p_revs):
 
     return ret
 
-def push_unsafe(repo, remote, parsed_refs, p_revs):
-
-    force = force_push
+def push_unsafe(repo, remote, p_revs, force):
 
     fci = discovery.findcommonincoming
     commoninc = fci(repo, remote, force=force)
     common, _, remoteheads = commoninc
     fco = discovery.findcommonoutgoing
     outgoing = fco(repo, remote, onlyheads=list(p_revs), commoninc=commoninc, force=force)
-
-    if not checkheads(repo, remote, p_revs):
-        return False
 
     # nice to know about this rather than assume a bogus error
     # also, some remote peertypes might otherwise be surprised further down
@@ -1193,7 +1188,7 @@ def push_unsafe(repo, remote, parsed_refs, p_revs):
 
     return ret
 
-def push(repo, remote, parsed_refs, p_revs):
+def push(repo, remote, p_revs, force):
     if hasattr(remote, 'canpush') and not remote.canpush():
         print "error cannot push"
 
@@ -1206,7 +1201,7 @@ def push(repo, remote, parsed_refs, p_revs):
     if not unbundle:
         lock = remote.lock()
     try:
-        ret = push_unsafe(repo, remote, parsed_refs, p_revs)
+        ret = push_unsafe(repo, remote, p_revs, force)
     finally:
         if lock is not None:
             lock.release()
@@ -1338,12 +1333,14 @@ def do_push_hg(parser):
 
     if dry_run:
         if peer and not force_push:
-            checkheads(parser.repo, peer, p_revs)
+            checkheads(parser.repo, peer, p_revs, force_push)
         return
 
     success = True
     if peer:
-        ret = push(parser.repo, peer, parsed_refs, p_revs)
+        if not checkheads(parser.repo, peer, p_revs, force_push):
+            return False
+        ret = push(parser.repo, peer, p_revs, force_push)
         # None ok: nothing to push
         if ret != None and not ret:
             # do not update bookmarks

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -1163,7 +1163,9 @@ def push_unsafe(repo, remote, p_revs, force):
     if not outgoing.missing:
         return None
 
-    if check_version(3, 2):
+    if check_version(4, 0):
+        cg = changegroup.getlocalchangegroup(repo, 'push', outgoing)
+    elif check_version(3, 2):
         cg = changegroup.getchangegroup(repo, 'push', heads=list(p_revs), common=common)
     elif check_version(3, 0):
         cg = changegroup.getbundle(repo, 'push', heads=list(p_revs), common=common)

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -217,6 +217,7 @@ class ParserContext:
         self.localref = None
         self.remoteref = None
         self.gitmarks = None
+        self.hghelper = None
 
 class Parser:
 
@@ -907,6 +908,45 @@ def parse_commit(parser):
         parsed_refs[ref] = None
         return
 
+    # check if this is an hg commit we have in some other repo
+    gitmarks = parser.context.gitmarks
+    if gitmarks:
+        gitcommit = gitmarks.to_rev(commit_mark)
+        hgrev = get_rev_hg(gitcommit)
+        if hgrev:
+            hghelper = parser.context.hghelper
+            if not hghelper:
+                print "error %s rejected not pushing hg based commit %s" % (ref, gitcommit)
+                raise UserWarning("check-hg-commits")
+            # must be in some local repo
+            # find it and push it to the target local repo
+            # (rather than making a commit into it)
+            # probably not already in target repo, but let's make sure
+            if hgrev not in parser.repo:
+                srepo = hghelper.githgrepo.find_hg_repo(hgrev)
+                if not srepo:
+                    # pretty bad, if identified as hg revision, we should have it somewhere
+                    # but is possible if the originating repo has been removed now
+                    # warn elaborately and fail given the current settings
+                    description = "\n" \
+                        "commit %s corresponds \nto hg revision %s,\n" \
+                        "but could not find latter in any fetched hg repo.\n" \
+                        "Please resolve the inconsistency or disable pushing hg commits" \
+                            % (gitcommit, hgrev)
+                    die(description)
+                warn('Pushing hg changeset %s for %s' % (hgrev, gitcommit))
+                # target is local repo so should have a root
+                # force push since otherwise forcibly commit anyway
+                # (and needed for multiple head case etc)
+                push(srepo, hg.peer(srepo.ui, {}, parser.repo.root), [hgbin(hgrev)], True)
+            else:
+                # could already be present, particularly in shared proxy repo
+                warn('Using hg changeset %s for %s' % (hgrev, gitcommit))
+            # track mark and are done here
+            parsed_refs[ref] = hgrev
+            marks.new_mark(hgrev, commit_mark)
+            return
+
     def getfilectx(repo, memctx, f):
         of = files[f]
         if 'deleted' in of:
@@ -1420,20 +1460,48 @@ def do_push_refspec(parser, refspec):
     marks = os.path.join(dirname, 'marks-git')
     if os.path.exists(marks):
         cmd.append('--import-marks=%s' % marks)
+    # optionally reuse existing hg commits in local repos
+    check_hg_commits = get_config('remote-hg.check-hg-commits').strip()
+    use_hg_commits = check_hg_commits in ('fail', 'push')
     # no commit of marks if dry-dry_run
     # and only commit if all went ok,
     # otherwise some commits may no longer be exported next time/try around
     tmpmarks = ''
-    if not dry_run:
+    if use_hg_commits or not dry_run:
         tmpmarks = os.path.join(dirname, 'marks-git-%d' % (os.getpid()))
         cmd.append('--export-marks=%s' % tmpmarks)
     cmd.append(refs[0])
-    export = subprocess.Popen(cmd, stdin=None, stdout=subprocess.PIPE)
     # a parameter would obviously be nicer here ...
     force_push = force
     ok = False
+    tmpfastexport = None
     try:
-        ok = do_push_hg(Parser(parser.repo, export.stdout, ctx))
+        if use_hg_commits:
+            # we need the mapping from marks to commit
+            # so store the output first to a file (and marks get saved also),
+            # and then process that file
+            tmpfastexport = open(os.path.join(dirname, 'git-fast-export-%d' % (os.getpid())), 'w+b')
+            subprocess.check_call(cmd, stdin=None, stdout=tmpfastexport)
+            try:
+                import imp
+                ctx.hghelper = imp.load_source('hghelper', \
+                    os.path.join(os.path.dirname(__file__), 'git-hg-helper'))
+                ctx.hghelper.init_git(gitdir)
+                ctx.gitmarks = ctx.hghelper.GitMarks(tmpmarks)
+                # let processing know it should not bother pushing if not requested
+                if check_hg_commits != 'push':
+                    ctx.hghelper = None
+            except:
+                die("check-hg-commits setup failed; is git-hg-helper also installed?")
+            tmpfastexport.seek(0)
+            try:
+                ok = do_push_hg(Parser(parser.repo, tmpfastexport, ctx))
+            except UserWarning:
+                ok = False
+        else:
+            # simply feed fast-export directly to processing
+            export = subprocess.Popen(cmd, stdin=None, stdout=subprocess.PIPE)
+            ok = do_push_hg(Parser(parser.repo, export.stdout, ctx))
     finally:
         if tmpmarks and os.path.exists(tmpmarks):
             if ok and not dry_run:
@@ -1441,6 +1509,9 @@ def do_push_refspec(parser, refspec):
                 os.rename(tmpmarks, marks)
             else:
                 os.remove(tmpmarks)
+        if tmpfastexport and os.path.exists(tmpfastexport.name):
+            tmpfastexport.close()
+            os.remove(tmpfastexport.name)
 
 def do_push(parser):
     if os.environ.get('GIT_REMOTE_HG_DEBUG_PUSH'):

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -1700,7 +1700,7 @@ def main(args):
         version, _, extra = util.version().partition('+')
         version = list(int(e) for e in version.split('.'))
         if extra:
-            version[1] += 1
+            version[-1] += 1
         hg_version = tuple(version)
     except:
         hg_version = None

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -470,7 +470,7 @@ def mark_to_rev(mark):
 def gitrange(repo, a, b):
     positive = []
     pending = set([int(b)])
-    negative = set([int(a)])
+    negative = int(a)
     for cur in xrange(b, -1, -1):
         if not pending:
             break
@@ -478,18 +478,12 @@ def gitrange(repo, a, b):
         parents = [p for p in repo.changelog.parentrevs(cur) if p >= 0]
 
         if cur in pending:
-            positive.append(cur)
+            if cur > negative:
+                positive.append(cur)
             pending.remove(cur)
             for p in parents:
-                if p not in negative:
+                if p > negative:
                     pending.add(p)
-        elif cur in negative:
-            negative.remove(cur)
-            for p in parents:
-                if p not in pending:
-                    negative.add(p)
-                else:
-                    pending.discard(p)
 
     positive.reverse()
     return positive

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -371,8 +371,19 @@ def fixup_user(user):
 
 def updatebookmarks(repo, peer):
     remotemarks = peer.listkeys('bookmarks')
-    localmarks = repo._bookmarks
 
+    # delete bookmarks locally that disappeared on remote
+    localmarks = bookmarks.listbookmarks(repo)
+    remote = set(remotemarks.keys())
+    local = set(localmarks.keys())
+    for bmark in local - remote:
+        bookmarks.pushbookmark(repo, bmark, localmarks[bmark], '')
+        # also delete private ref
+        pbookmark = '%s/bookmarks/%s' % (prefix, bmark)
+        subprocess.call(['git', 'update-ref', '-d', pbookmark])
+
+    # now add or update remote bookmarks to local, if any
+    localmarks = repo._bookmarks
     if not remotemarks:
         return
 
@@ -1320,8 +1331,8 @@ def main(args):
     dry_run = False
     notes = set()
 
-    repo = get_repo(url, alias)
     prefix = 'refs/hg/%s' % alias
+    repo = get_repo(url, alias)
 
     if not is_tmp:
         fix_path(alias, peer or repo, url)

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -96,8 +96,8 @@ def check_version(*check):
         return True
     return hg_version >= check
 
-def get_config(config):
-    cmd = ['git', 'config', '--get', config]
+def get_config(config, getall=False):
+    cmd = ['git', 'config', '--get' if not getall else '--get-all', config]
     process = subprocess.Popen(cmd, stdout=subprocess.PIPE)
     output, _ = process.communicate()
     return output
@@ -707,6 +707,22 @@ def do_list(parser):
 
     list_head(repo, cur)
 
+    ignore_ref = get_config('remote-hg.ignore-name', True)
+    ignore_re = []
+    for exp in ignore_ref.splitlines():
+        if exp:
+            try:
+                #warn("checking %s" % (
+                ignore_re.append(re.compile(exp.strip()))
+            except:
+                warn("Invalid regular expression '%s'" % (exp))
+    def ignore(kind, name):
+        for r in ignore_re:
+            if r.search(name):
+                warn("Ignoring matched %s %s" % (kind, name))
+                return True
+        return False
+
     # for export command a ref's old_sha1 is taken from private namespace ref
     # for push command a fake one is provided
     # that avoids having the ref status reported as a new branch/tag
@@ -717,18 +733,20 @@ def do_list(parser):
 
     if track_branches:
         for branch in branches:
-            print "%s refs/heads/branches/%s" % (sha1, gitref(branch))
+            if not ignore('branch', branch):
+                print "%s refs/heads/branches/%s" % (sha1, gitref(branch))
 
     for bmark in bmarks:
         if bmarks[bmark].hex() == '0' * 40:
             warn("Ignoring invalid bookmark '%s'", bmark)
-        else:
+        elif not ignore('bookmark', bmark):
             print "%s refs/heads/%s" % (sha1, gitref(bmark))
 
     for tag, node in repo.tagslist():
         if tag == 'tip':
             continue
-        print "%s refs/tags/%s" % (sha1, gitref(tag))
+        if not ignore('tag', tag):
+            print "%s refs/tags/%s" % (sha1, gitref(tag))
 
     print
 

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -1302,7 +1302,13 @@ def do_push_hg(parser):
                 tagnode, branch = write_tag(parser.repo, tag, node, msg, author)
                 p_revs[tagnode] = 'refs/heads/branches/' + gitref(branch)
             else:
-                fp = parser.repo.opener('localtags', 'a')
+                if hasattr(parser.repo, 'opener'):
+                    fp = parser.repo.opener('localtags', 'a')
+                else:
+                  try:
+                      fp = parser.repo.vfs('localtags', 'r+')
+                  except IOError:
+                      fp = parser.repo.vfs('localtags', 'a')
                 fp.write('%s %s\n' % (node, tag))
                 fp.close()
             p_revs[bnode] = ref

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -830,6 +830,15 @@ def c_style_unescape(string):
         return string.decode('string-escape')[1:-1]
     return string
 
+# sigh; handle context creation for various (incompatible) versions
+def make_memfilectx(repo, memctx, path, data, is_link, is_exec, *args):
+    if check_version(4, 5):
+        return context.memfilectx(repo, memctx, path, data, is_link, is_exec, *args)
+    if check_version(3, 1):
+        return context.memfilectx(repo, path, data, is_link, is_exec, *args)
+    else:
+        return context.memfilectx(path, data, is_link, is_exec, *args)
+
 def parse_commit(parser):
     from_mark = merge_mark = None
 
@@ -945,23 +954,13 @@ def parse_commit(parser):
                 ctx = of['ctx']
                 is_exec = ctx.isexec()
                 is_link = ctx.islink()
-                if check_version(3, 1):
-                    return context.memfilectx(repo, f, ctx.data(),
-                            is_link, is_exec)
-                else:
-                    return context.memfilectx(f, ctx.data(),
-                            is_link, is_exec)
+                return make_memfilectx(repo, memctx, f, ctx.data(), is_link, is_exec)
             else:
                 return of['ctx']
         is_exec = of['mode'] == 'x'
         is_link = of['mode'] == 'l'
         rename = of.get('rename', None)
-        if check_version(3, 1):
-            return context.memfilectx(repo, f, of['data'],
-                    is_link, is_exec, rename)
-        else:
-            return context.memfilectx(f, of['data'],
-                    is_link, is_exec, rename)
+        return make_memfilectx(repo, memctx, f, of['data'], is_link, is_exec, rename)
 
     repo = parser.repo
 
@@ -1071,10 +1070,7 @@ def write_tag(repo, tag, node, msg, author):
         except error.ManifestLookupError:
             data = ""
         content = data + "%s %s\n" % (node, tag)
-        if check_version(3, 1):
-            return context.memfilectx(repo, f, content, False, False, None)
-        else:
-            return context.memfilectx(f, content, False, False, None)
+        return make_memfilectx(repo, memctx, f, content, False, False, None)
 
     p1 = tip.hex()
     p2 = '0' * 40

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -334,7 +334,9 @@ def get_filechanges(repo, ctx, parent):
 
 def fixup_user_git(user):
     name = mail = None
-    user = user.replace('"', '')
+    global remove_username_quotes
+    if remove_username_quotes:
+        user = user.replace('"', '')
     m = AUTHOR_RE.match(user)
     if m:
         name = m.group(1)
@@ -1646,6 +1648,7 @@ def main(args):
     global dry_run
     global notes, alias
     global capability_push
+    global remove_username_quotes
     global marksdir
 
     marks = None
@@ -1665,6 +1668,7 @@ def main(args):
     hg_git_compat = get_config_bool('remote-hg.hg-git-compat')
     track_branches = get_config_bool('remote-hg.track-branches', True)
     capability_push = get_config_bool('remote-hg.capability-push', True)
+    remove_username_quotes = get_config_bool('remote-hg.remove-username-quotes', True)
     force_push = False
 
     if hg_git_compat:

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -1573,9 +1573,9 @@ def do_push(parser):
             die('unhandled push command: %s' % (line))
     print
     # at this stage, all external processes are done, marks files written
-    # so we can use those do update notes if so desired
-    if get_config_bool('remote-hg.push-updates-notes') and revs:
-        update_notes(revs, "Update notes on push")
+    # so we can use those to update notes
+    # do so unconditionally because we can and should ....
+    update_notes(revs, "Update notes on push")
 
 def do_option(parser):
     global dry_run, force_push

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -403,6 +403,13 @@ def updatebookmarks(repo, peer):
     if not remotemarks:
         return
 
+    # use a higher level API from now on than the lower one below
+    if check_version(4,6):
+        for k, v in remotemarks.iteritems():
+            old = hghex(localmarks.get(k, ''))
+            bookmarks.pushbookmark(repo, k, old, v)
+        return
+
     for k, v in remotemarks.iteritems():
         localmarks[k] = hgbin(v)
 

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -110,6 +110,12 @@ def get_config_bool(config, default=False):
     else:
         return default
 
+def rev_parse(rev):
+    cmd = ['git', 'rev-parse', '--verify', '-q', rev]
+    process = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+    output, _ = process.communicate()
+    return output
+
 class Marks:
 
     def __init__(self, path, repo):
@@ -602,8 +608,11 @@ def export_ref(repo, name, kind, head):
         desc = "Notes for %s\n" % (name)
         print "data %d" % (len(desc))
         print desc
-        if marks.last_note:
-            print "from :%u" % marks.last_note
+        # continue incrementally on current notes branch (whenever possible)
+        # to avoid wiping out present content upon fetch of new repo
+        current_note = rev_parse(ref)
+        if current_note:
+            print 'from %s^0' % (ref)
 
         for rev in pending_revs:
             notes.add(rev)

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -1574,6 +1574,86 @@ def select_private_refs(alias):
         # keep private implementation refs really private
         return 'hg/%s/refs' % alias
 
+def select_marks_dir(alias, gitdir, migrate):
+    dirname = os.path.join(gitdir, 'hg', alias)
+    private_gm = os.path.join(dirname, 'marks-git')
+    shared_dir = os.path.join(gitdir, 'hg')
+    shared_gm = os.path.join(shared_dir, 'marks-git')
+    shared_hgm = os.path.join(shared_dir, 'marks-hg')
+    # not good in either case
+    if os.path.exists(private_gm) and os.path.exists(shared_gm):
+        die('found both %s and %s' % (private_gm, shared_gm))
+    # retrieve setting
+    shared_marks = get_config('remote-hg.shared-marks').strip()
+    # standardize to True, False or None
+    shared_marks = get_config_bool('remote-hg.shared-marks', False) \
+        if shared_marks else None
+    # if no specific setting, select one here (favouring shared for new installation)
+    if shared_marks == None:
+        # select one automagically, favouring shared for new installation
+        if os.path.exists(private_gm):
+            shared_marks = False
+        elif not os.path.exists(shared_gm) and os.path.exists(shared_dir):
+            # not a fresh clone, but no shared setup, so use private
+            shared_marks = False
+        else:
+            shared_marks = True
+        # only migrate with explicit setting
+        migrate = False
+    # otherwise, there is not much to decide
+    # but a migration from one setup to the other might be needed
+    l = os.listdir(shared_dir) if os.path.exists(shared_dir) and migrate else []
+    if shared_marks and migrate:
+        # make sure all local ones are cleaned up
+        # use one of these (preferably origin) to seed the shared
+        seen_file = False
+        while l:
+            d = l.pop()
+            gitm = os.path.join(shared_dir, d, 'marks-git')
+            hgm = os.path.join(shared_dir, d, 'marks-hg')
+            # move marks to shared if no such yet (if origin or last one in line)
+            if os.path.exists(gitm) and os.path.exists(hgm) and \
+              not os.path.exists(shared_gm) and not os.path.exists(shared_gm) and \
+              (d == 'origin' or not l):
+                warn('using marks of remote %s as shared marks' % (d))
+                seen_file = True
+                os.rename(gitm, shared_gm)
+                os.rename(hgm, shared_hgm)
+            for p in (gitm, hgm):
+                if os.path.exists(p):
+                   seen_file = True
+                   os.remove(p)
+        # all private marks removed, should have shared
+        if seen_file and (not os.path.exists(shared_gm) or not os.path.exists(shared_gm)):
+            die('migration to shared marks failed; perform fetch to recover')
+    elif migrate:
+        if not os.path.exists(shared_gm) or not os.path.exists(shared_hgm):
+            l = []
+        for d in l:
+            if not os.path.isdir(os.path.join(shared_dir, d)) or d == '.hg':
+                continue
+            gitm = os.path.join(shared_dir, d, 'marks-git')
+            hgm = os.path.join(shared_dir, d, 'marks-hg')
+            for p in ((shared_gm, gitm), (shared_hgm, hgm)):
+                if os.path.exists(p[0]):
+                   shutil.copyfile(p[0], p[1])
+                # try to run helper gc
+                # only really important for a local repo (without proxy)
+            warn('seeded marks of %s with shared; performing gc' % d)
+            try:
+                subprocess.check_call(['git-hg-helper', 'gc', '--check-hg', d],
+                    stdout=sys.stderr)
+            except:
+                warn('gc for %s failed' % d)
+            for p in (shared_gm, shared_hgm):
+                if os.path.exists(p):
+                   os.remove(p)
+    if shared_marks:
+        # force proxy for local repo
+        os.environ['GIT_REMOTE_HG_TEST_REMOTE'] = 'y'
+        return shared_dir
+    return dirname
+
 def main(args):
     global prefix, gitdir, dirname, branches, bmarks
     global marks, blob_marks, parsed_refs
@@ -1641,12 +1721,12 @@ def main(args):
         warn('various enhanced features might fail in subtle ways')
 
     prefix = select_private_refs(alias)
+    marksdir = select_marks_dir(alias, gitdir, True)
     repo = get_repo(url, alias)
 
     if not is_tmp:
         fix_path(alias, peer or repo, url)
 
-    marksdir = dirname
     marks_path = os.path.join(marksdir, 'marks-hg')
     marks = Marks(marks_path, repo)
 

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -218,6 +218,7 @@ class ParserContext:
         self.remoteref = None
         self.gitmarks = None
         self.hghelper = None
+        self.revs = []
 
 class Parser:
 
@@ -1040,6 +1041,7 @@ def parse_commit(parser):
 
     parsed_refs[ref] = node
     marks.new_mark(node, commit_mark)
+    parser.context.revs.append(node)
 
 def parse_reset(parser):
     remoteref = parser.context.remoteref
@@ -1425,7 +1427,7 @@ def delete_bookmark(parser, ref):
             subprocess.call(['git', 'update-ref', '-d', pbookmark])
     return ok
 
-def do_push_refspec(parser, refspec):
+def do_push_refspec(parser, refspec, revs):
     global force_push
 
     force = (refspec[0] == '+')
@@ -1495,23 +1497,56 @@ def do_push_refspec(parser, refspec):
                 die("check-hg-commits setup failed; is git-hg-helper also installed?")
             tmpfastexport.seek(0)
             try:
-                ok = do_push_hg(Parser(parser.repo, tmpfastexport, ctx))
+                nparser = Parser(parser.repo, tmpfastexport, ctx)
+                ok = do_push_hg(nparser)
             except UserWarning:
                 ok = False
         else:
             # simply feed fast-export directly to processing
             export = subprocess.Popen(cmd, stdin=None, stdout=subprocess.PIPE)
-            ok = do_push_hg(Parser(parser.repo, export.stdout, ctx))
+            nparser = Parser(parser.repo, export.stdout, ctx)
+            ok = do_push_hg(nparser)
     finally:
         if tmpmarks and os.path.exists(tmpmarks):
             if ok and not dry_run:
                 # the commits made it through, now we can commit
                 os.rename(tmpmarks, marks)
+                revs[:] = nparser.context.revs
             else:
                 os.remove(tmpmarks)
         if tmpfastexport and os.path.exists(tmpfastexport.name):
             tmpfastexport.close()
             os.remove(tmpfastexport.name)
+
+def update_notes(revs, desc):
+    if revs:
+        # spin up fast-import
+        gitmarks = os.path.join(dirname, 'marks-git')
+        # marks should exist by now
+        # no export of marks since notes commits are not relevant
+        proc = subprocess.Popen(['git', 'fast-import', '--done', '--quiet',
+            '--import-marks=%s' % gitmarks], stdin=subprocess.PIPE, stdout=sys.stderr)
+        # now feed fast-import
+        dest = proc.stdin
+
+        note_mark = marks.next_mark()
+        ref = "refs/notes/hg"
+        dest.write("commit %s\n" % ref)
+        dest.write("mark :%d\n" % (note_mark))
+        dest.write("committer remote-hg <> %d %s\n" % (ptime.time(), gittz(ptime.timezone)))
+        dest.write("data %d\n" % (len(desc)))
+        dest.write(desc + '\n')
+        current_note = rev_parse(ref)
+        if current_note:
+            dest.write('from %s^0\n' % (ref))
+        for rev in revs:
+            dest.write("N inline :%u\n" % marks.from_rev(rev))
+            dest.write("data %d\n" % (len(rev)))
+            dest.write(rev + '\n')
+        dest.write('\n')
+        dest.write('done\n')
+        dest.flush()
+        proc.wait()
 
 def do_push(parser):
     if os.environ.get('GIT_REMOTE_HG_DEBUG_PUSH'):
@@ -1519,12 +1554,19 @@ def do_push(parser):
         for line in parser:
             dump += line + '\n'
         die('DEBUG push:\n%s' % (dump))
+    revs = []
     for line in parser:
         if parser.check('push'):
-            do_push_refspec(parser, line.lstrip('push '))
+            localrevs = []
+            do_push_refspec(parser, line.lstrip('push '), localrevs)
+            revs.extend(localrevs)
         else:
             die('unhandled push command: %s' % (line))
     print
+    # at this stage, all external processes are done, marks files written
+    # so we can use those do update notes if so desired
+    if get_config_bool('remote-hg.push-updates-notes') and revs:
+        update_notes(revs, "Update notes on push")
 
 def do_option(parser):
     global dry_run, force_push

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -772,6 +772,25 @@ def parse_blob(parser):
     blob_marks[mark] = data
     parser.next()
 
+def get_file_metadata(repo, p1, files):
+    for e in files:
+        f = files[e]
+        if 'rename' in f and 'mode' not in f:
+            old = f['rename']
+            ctx = repo[p1][old]
+            m = ''
+            # .isexec(), .islink() only around in newer versions
+            if hasattr(ctx, 'isexec'):
+                m = ctx.isexec()
+            else:
+                m = ('x' in ctx.flags())
+            if hasattr(ctx, 'islink'):
+                m = ctx.islink()
+            else:
+                m = ('l' in ctx.flags())
+            f['mode'] = m
+            f['data'] = ctx.data()
+
 def get_merge_files(repo, p1, p2, files):
     for e in repo[p1].files():
         if e not in files:
@@ -779,6 +798,19 @@ def get_merge_files(repo, p1, p2, files):
                 continue
             f = { 'ctx': repo[p1][e] }
             files[e] = f
+
+def split_line_pathnames(line):
+    if line[2] != '"':
+        return line.split(' ', 2)
+    else:
+        t = line[0]
+        p = 3
+        while p >= 0:
+            if line[p] == '"' and line[p - 1] != '\\':
+                return line[0], line[2:p+1], line[p+2:]
+            p = line.find('"', p + 1)
+        # hm, should not happen
+        die('Malformed file command: %s' % (line))
 
 def c_style_unescape(string):
     if string[0] == string[-1] == '"':
@@ -822,10 +854,20 @@ def parse_commit(parser):
         elif parser.check('D'):
             t, path = line.split(' ', 1)
             f = { 'deleted': True }
+        elif parser.check('R'):
+            t, old, path = split_line_pathnames(line)
+            old = c_style_unescape(old)
+            f = { 'rename': old }
+            # also mark old deleted
+            files[old] = { 'deleted': True }
+        elif parser.check('C'):
+            t, old, path = split_line_pathnames(line)
+            f = { 'rename': c_style_unescape(old) }
         else:
             die('Unknown file command: %s' % line)
         path = c_style_unescape(path)
-        files[path] = f
+        files[path] = files.get(path, {})
+        files[path].update(f)
 
     # only export the commits if we are on an internal proxy repo
     if dry_run and not peer:
@@ -886,6 +928,11 @@ def parse_commit(parser):
     #
     if merge_mark:
         get_merge_files(repo, p1, p2, files)
+
+    # need to obtain file metadata for copied and renamed files that have
+    # no filemodify line; let's get that from the old file in parent revision
+    if from_mark:
+        get_file_metadata(repo, p1, files)
 
     # Check if the ref is supposed to be a named branch
     if ref.startswith('refs/heads/branches/'):

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -1395,7 +1395,7 @@ def do_push_refspec(parser, refspec, revs):
     # check for delete
     if (not refs[0]) and refs[1].startswith('refs/heads') and \
             not refs[1].startswith('refs/heads/branches'):
-        if not delete_bookmark(parser, refs[1]):
+        if not dry_run and not delete_bookmark(parser, refs[1]):
             print "error %s could not delete"% (refs[1])
         else:
             print "ok %s" % (refs[1])

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -1550,6 +1550,12 @@ def update_notes(revs, desc):
         dest.write('done\n')
         dest.flush()
         proc.wait()
+        # fail hard if this fails
+        # that prevents the marks file from being written
+        # so we can have a fresh look with a fetch
+        if proc.returncode:
+            die('notes update failed with return %d; recover with git fetch' %
+                (proc.returncode))
 
 def do_push(parser):
     if os.environ.get('GIT_REMOTE_HG_DEBUG_PUSH'):

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -1478,6 +1478,25 @@ def fix_path(alias, repo, orig_url):
     cmd = ['git', 'config', 'remote.%s.url' % alias, "hg::%s" % abs_url]
     subprocess.call(cmd)
 
+def select_private_refs(alias):
+    show_private_refs = get_config_bool('remote-hg.show-private-refs', False)
+    # selection is easy, but let's also clean the refs of the alternative
+    # in any case, will be recreated along the way as and when needed
+    if show_private_refs:
+        path = "%s/refs" % (dirname)
+        if os.path.exists(path):
+            shutil.rmtree(path, True)
+        # in refs space
+        return 'refs/hg/%s' % alias
+    else:
+        refs = subprocess.Popen(['git', 'for-each-ref', \
+            '--format=delete %(refname)', 'refs/hg'], stdout=subprocess.PIPE)
+        update = subprocess.Popen(['git', 'update-ref', '--stdin'], stdin=refs.stdout)
+        refs.stdout.close()  # helps with SIGPIPE
+        update.communicate()
+        # keep private implementation refs really private
+        return 'hg/%s/refs' % alias
+
 def main(args):
     global prefix, gitdir, dirname, branches, bmarks
     global marks, blob_marks, parsed_refs
@@ -1539,7 +1558,7 @@ def main(args):
     dry_run = False
     notes = set()
 
-    prefix = 'refs/hg/%s' % alias
+    prefix = select_private_refs(alias)
     repo = get_repo(url, alias)
 
     if not is_tmp:

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -158,7 +158,7 @@ class Marks:
         self.marks = tmp['marks']
         self.last_mark = tmp['last-mark']
         self.version = tmp.get('version', 1)
-        self.last_note = tmp.get('last-note', 0)
+        self.last_note = 0
 
         for rev, mark in self.marks.iteritems():
             self.rev_marks[mark] = rev
@@ -612,34 +612,9 @@ def export_ref(repo, name, kind, head):
 
     pending_revs = set(revs) - notes
     if pending_revs:
-        note_mark = marks.next_mark()
-        ref = "refs/notes/hg"
-
-        print "commit %s" % ref
-        print "mark :%d" % (note_mark)
-        print "committer remote-hg <> %d %s" % (ptime.time(), gittz(ptime.timezone))
         desc = "Notes for %s\n" % (name)
-        print "data %d" % (len(desc))
-        print desc
-        # continue incrementally on current notes branch (whenever possible)
-        # to avoid wiping out present content upon fetch of new repo
-        current_note = rev_parse(ref)
-        if current_note and not len(notes):
-            print 'from %s^0' % (ref)
-        # but track along with the previous ref as import goes along
-        elif marks.last_note:
-            print "from :%u" % (marks.last_note)
-
-        for rev in pending_revs:
-            notes.add(rev)
-            c = repo[rev]
-            print "N inline :%u" % rev_to_mark(c)
-            msg = c.hex()
-            print "data %d" % (len(msg))
-            print msg
-        print
-
-        marks.last_note = note_mark
+        update_notes([repo[rev].hex() for rev in pending_revs], desc, False)
+        notes.update(pending_revs)
 
 def export_tag(repo, tag):
     export_ref(repo, tag, 'tags', repo[hgref(tag)])
@@ -1479,8 +1454,11 @@ def do_push_refspec(parser, refspec, revs):
             tmpfastexport.close()
             os.remove(tmpfastexport.name)
 
-def update_notes(revs, desc):
-    if revs:
+def update_notes(revs, desc, run_import):
+    if not revs:
+        return
+
+    if run_import:
         # spin up fast-import
         gitmarks = os.path.join(marksdir, 'marks-git')
         # marks should exist by now
@@ -1489,22 +1467,33 @@ def update_notes(revs, desc):
             '--import-marks=%s' % gitmarks], stdin=subprocess.PIPE, stdout=sys.stderr)
         # now feed fast-import
         dest = proc.stdin
+    else:
+        proc = None
+        dest = sys.stdout
 
-        note_mark = marks.next_mark()
-        ref = "refs/notes/hg"
-        dest.write("commit %s\n" % ref)
-        dest.write("mark :%d\n" % (note_mark))
-        dest.write("committer remote-hg <> %d %s\n" % (ptime.time(), gittz(ptime.timezone)))
-        dest.write("data %d\n" % (len(desc)))
-        dest.write(desc + '\n')
-        current_note = rev_parse(ref)
-        if current_note:
-            dest.write('from %s^0\n' % (ref))
-        for rev in revs:
-            dest.write("N inline :%u\n" % marks.from_rev(rev))
-            dest.write("data %d\n" % (len(rev)))
-            dest.write(rev + '\n')
-        dest.write('\n')
+    note_mark = marks.next_mark()
+    ref = "refs/notes/hg"
+    dest.write("commit %s\n" % ref)
+    dest.write("mark :%d\n" % (note_mark))
+    dest.write("committer remote-hg <> %d %s\n" % (ptime.time(), gittz(ptime.timezone)))
+    dest.write("data %d\n" % (len(desc)))
+    dest.write(desc + '\n')
+    # continue incrementally on current notes branch (whenever possible)
+    # to avoid wiping out present content upon fetch of new repo
+    # but track along with the previous ref (e.g. as import goes along)
+    current_note = rev_parse(ref)
+    if current_note and not marks.last_note:
+        dest.write('from %s^0\n' % (ref))
+    elif marks.last_note:
+        dest.write('from :%u\n' % (marks.last_note))
+    for rev in revs:
+        dest.write("N inline :%u\n" % marks.from_rev(rev))
+        dest.write("data %d\n" % (len(rev)))
+        dest.write(rev + '\n')
+    dest.write('\n')
+    marks.last_note = note_mark
+
+    if proc:
         dest.write('done\n')
         dest.flush()
         proc.wait()
@@ -1533,7 +1522,7 @@ def do_push(parser):
     # at this stage, all external processes are done, marks files written
     # so we can use those to update notes
     # do so unconditionally because we can and should ....
-    update_notes(revs, "Update notes on push")
+    update_notes(revs, "Update notes on push", True)
 
 def do_option(parser):
     global dry_run, force_push

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -1,6 +1,7 @@
 #!/usr/bin/env python2
 #
 # Copyright (c) 2012 Felipe Contreras
+# Copyright (c) 2016 Mark Nauwelaerts
 #
 
 # Inspired by Rocco Rutte's hg-fast-export

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -285,10 +285,16 @@ class Parser:
         return (user, int(date), -tz)
 
 def fix_file_path(path):
+    def posix_path(path):
+        if os.sep == '/':
+            return path
+        # even Git for Windows expects forward
+        return path.replace(os.sep, '/')
+    # also converts forward slash to backwards slash on Win
     path = os.path.normpath(path)
     if not os.path.isabs(path):
-        return path
-    return os.path.relpath(path, '/')
+        return posix_path(path)
+    return posix_path(os.path.relpath(path, '/'))
 
 def export_files(files):
     final = []

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -666,7 +666,7 @@ def do_capabilities(parser):
     print "refspec refs/heads/*:%s/bookmarks/*" % prefix
     print "refspec refs/tags/*:%s/tags/*" % prefix
 
-    path = os.path.join(dirname, 'marks-git')
+    path = os.path.join(marksdir, 'marks-git')
 
     if os.path.exists(path):
         print "*import-marks %s" % path
@@ -755,7 +755,7 @@ def do_list(parser):
 def do_import(parser):
     repo = parser.repo
 
-    path = os.path.join(dirname, 'marks-git')
+    path = os.path.join(marksdir, 'marks-git')
 
     print "feature done"
     if os.path.exists(path):
@@ -1419,7 +1419,7 @@ def do_push_refspec(parser, refspec, revs):
     if not fast_export_options:
         fast_export_options = '-M -C'
     cmd.extend(fast_export_options.strip().split())
-    marks = os.path.join(dirname, 'marks-git')
+    marks = os.path.join(marksdir, 'marks-git')
     if os.path.exists(marks):
         cmd.append('--import-marks=%s' % marks)
     # optionally reuse existing hg commits in local repos
@@ -1430,7 +1430,7 @@ def do_push_refspec(parser, refspec, revs):
     # otherwise some commits may no longer be exported next time/try around
     tmpmarks = ''
     if use_hg_commits or not dry_run:
-        tmpmarks = os.path.join(dirname, 'marks-git-%d' % (os.getpid()))
+        tmpmarks = os.path.join(marksdir, 'marks-git-%d' % (os.getpid()))
         cmd.append('--export-marks=%s' % tmpmarks)
     cmd.append(refs[0])
     # a parameter would obviously be nicer here ...
@@ -1442,7 +1442,7 @@ def do_push_refspec(parser, refspec, revs):
             # we need the mapping from marks to commit
             # so store the output first to a file (and marks get saved also),
             # and then process that file
-            tmpfastexport = open(os.path.join(dirname, 'git-fast-export-%d' % (os.getpid())), 'w+b')
+            tmpfastexport = open(os.path.join(marksdir, 'git-fast-export-%d' % (os.getpid())), 'w+b')
             subprocess.check_call(cmd, stdin=None, stdout=tmpfastexport)
             try:
                 import imp
@@ -1482,7 +1482,7 @@ def do_push_refspec(parser, refspec, revs):
 def update_notes(revs, desc):
     if revs:
         # spin up fast-import
-        gitmarks = os.path.join(dirname, 'marks-git')
+        gitmarks = os.path.join(marksdir, 'marks-git')
         # marks should exist by now
         # no export of marks since notes commits are not relevant
         proc = subprocess.Popen(['git', 'fast-import', '--done', '--quiet',
@@ -1585,6 +1585,7 @@ def main(args):
     global dry_run
     global notes, alias
     global capability_push
+    global marksdir
 
     marks = None
     is_tmp = False
@@ -1645,7 +1646,8 @@ def main(args):
     if not is_tmp:
         fix_path(alias, peer or repo, url)
 
-    marks_path = os.path.join(dirname, 'marks-hg')
+    marksdir = dirname
+    marks_path = os.path.join(marksdir, 'marks-hg')
     marks = Marks(marks_path, repo)
 
     if sys.platform == 'win32':

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -1602,7 +1602,7 @@ def select_marks_dir(alias, gitdir, migrate):
             hgm = os.path.join(shared_dir, d, 'marks-hg')
             # move marks to shared if no such yet (if origin or last one in line)
             if os.path.exists(gitm) and os.path.exists(hgm) and \
-              not os.path.exists(shared_gm) and not os.path.exists(shared_gm) and \
+              not os.path.exists(shared_gm) and not os.path.exists(shared_hgm) and \
               (d == 'origin' or not l):
                 warn('using marks of remote %s as shared marks' % (d))
                 seen_file = True
@@ -1613,7 +1613,7 @@ def select_marks_dir(alias, gitdir, migrate):
                    seen_file = True
                    os.remove(p)
         # all private marks removed, should have shared
-        if seen_file and (not os.path.exists(shared_gm) or not os.path.exists(shared_gm)):
+        if seen_file and (not os.path.exists(shared_gm) or not os.path.exists(shared_hgm)):
             die('migration to shared marks failed; perform fetch to recover')
     elif migrate:
         if not os.path.exists(shared_gm) or not os.path.exists(shared_hgm):

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -1078,8 +1078,15 @@ def push_unsafe(repo, remote, parsed_refs, p_revs):
     fci = discovery.findcommonincoming
     commoninc = fci(repo, remote, force=force)
     common, _, remoteheads = commoninc
+    fco = discovery.findcommonoutgoing
+    outgoing = fco(repo, remote, onlyheads=list(p_revs), commoninc=commoninc, force=force)
 
     if not checkheads(repo, remote, p_revs):
+        return False
+
+    # nice to know about this rather than assume a bogus error
+    # also, some remote peertypes might otherwise be surprised further down
+    if not outgoing.missing:
         return None
 
     if check_version(3, 2):
@@ -1230,7 +1237,9 @@ def do_export(parser):
         return
 
     if peer:
-        if not push(parser.repo, peer, parsed_refs, p_revs):
+        ret = push(parser.repo, peer, parsed_refs, p_revs)
+        # None ok: nothing to push
+        if ret != None and not ret:
             # do not update bookmarks
             print
             return

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -634,8 +634,11 @@ def export_ref(repo, name, kind, head):
         # continue incrementally on current notes branch (whenever possible)
         # to avoid wiping out present content upon fetch of new repo
         current_note = rev_parse(ref)
-        if current_note:
+        if current_note and not len(notes):
             print 'from %s^0' % (ref)
+        # but track along with the previous ref as import goes along
+        elif marks.last_note:
+            print "from :%u" % (marks.last_note)
 
         for rev in pending_revs:
             notes.add(rev)

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -840,8 +840,14 @@ def parse_commit(parser):
     for line in parser:
         if parser.check('M'):
             t, m, mark_ref, path = line.split(' ', 3)
-            mark = int(mark_ref[1:])
-            f = { 'mode': hgmode(m), 'data': blob_marks[mark] }
+            if m == '160000':
+                # This is a submodule -- there is no reasonable
+                # way to import it.
+                blob_data = "[git-remote-hg: skipped import of submodule at %s]" % mark_ref
+            else:
+                mark = int(mark_ref[1:])
+                blob_data = blob_marks[mark]
+            f = { 'mode': hgmode(m), 'data': blob_data }
         elif parser.check('D'):
             t, path = line.split(' ', 1)
             f = { 'deleted': True }

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -495,24 +495,30 @@ def rev_to_mark(rev):
 def mark_to_rev(mark):
     return marks.to_rev(mark)
 
-# Get a range of revisions in the form of a..b (git committish)
-def gitrange(repo, a, b):
+# Walk backwards from revision b to determine which need importing
+# For repos with many heads (and loooots of tagging) this walk should
+# end as soon as possible, so use all the known revisions are negative.
+def revwalk(repo, name, b):
     positive = []
-    pending = set([int(b)])
-    negative = int(a)
+    pending = set()
+    if not marks.is_marked(b.hex()):
+        pending.add(int(b))
+    interval = int(b) / 10
+    interval = interval if interval > 1000 else 1000
     for cur in xrange(b, -1, -1):
         if not pending:
             break
 
-        parents = [p for p in repo.changelog.parentrevs(cur) if p >= 0]
-
         if cur in pending:
-            if cur > negative:
-                positive.append(cur)
+            positive.append(cur)
             pending.remove(cur)
+            parents = [p for p in repo.changelog.parentrevs(cur) if p >= 0]
             for p in parents:
-                if p > negative:
+                if not marks.is_marked(repo[p].hex()):
                     pending.add(p)
+
+        if cur % interval == 0:
+            print "progress revision walk '%s' (%d/%d)" % (name, (int(b) - cur), int(b))
 
     positive.reverse()
     return positive
@@ -525,7 +531,7 @@ def export_ref(repo, name, kind, head):
     except:
         tip = repo[-1]
 
-    revs = gitrange(repo, tip, head)
+    revs = revwalk(repo, ename, head)
 
     total = len(revs)
     tip = tip.rev()
@@ -534,9 +540,6 @@ def export_ref(repo, name, kind, head):
 
         c = repo[rev]
         node = c.node()
-
-        if marks.is_marked(c.hex()):
-            continue
 
         (manifest, user, (time, tz), files, desc, extra) = repo.changelog.read(node)
         rev_branch = extra['branch']

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -427,7 +427,10 @@ def updatebookmarks(repo, peer):
 def get_repo(url, alias):
     global peer
 
-    myui = ui.ui.load()
+    if hasattr(ui.ui, 'load'):
+        myui = ui.ui.load()
+    else:
+        myui = ui.ui()
     myui.setconfig('ui', 'interactive', 'off')
     myui.fout = sys.stderr
 

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -1595,5 +1595,6 @@ def bye():
     if is_tmp:
         shutil.rmtree(dirname)
 
-atexit.register(bye)
-sys.exit(main(sys.argv))
+if __name__ == '__main__':
+    atexit.register(bye)
+    sys.exit(main(sys.argv))

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -1677,6 +1677,10 @@ def main(args):
     dry_run = False
     notes = set()
 
+    if not capability_push:
+        warn('capability_push is disabled, only do so when really sure')
+        warn('various enhanced features might fail in subtle ways')
+
     prefix = select_private_refs(alias)
     repo = get_repo(url, alias)
 

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -1489,6 +1489,11 @@ def do_push_refspec(parser, refspec, revs):
         if tmpmarks and os.path.exists(tmpmarks):
             if ok and not dry_run:
                 # the commits made it through, now we can commit
+                # sigh ... no atomic rename for existing destination on some platform ...
+                # (use unofficial platform check)
+                if os.sep != '/':
+                  if os.path.exists(marks):
+                    os.remove(marks)
                 os.rename(tmpmarks, marks)
                 revs[:] = nparser.context.revs
             else:

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -1425,7 +1425,7 @@ def do_push_refspec(parser, refspec, revs):
     # optionally reuse existing hg commits in local repos
     check_hg_commits = get_config('remote-hg.check-hg-commits').strip()
     use_hg_commits = check_hg_commits in ('fail', 'push')
-    # no commit of marks if dry-dry_run
+    # no commit of marks if dry_run
     # and only commit if all went ok,
     # otherwise some commits may no longer be exported next time/try around
     tmpmarks = ''

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -664,6 +664,11 @@ def do_capabilities(parser):
         print "*import-marks %s" % path
     print "*export-marks %s" % path
     print "option"
+    # nothing really depends on the private refs being up to date
+    # (export is limited anyway by the current git marks)
+    # and they are not always updated correctly (dry-run, bookmark delete, ...)
+    # (might resolve some dry-run breakage also)
+    print "no-private-update"
 
     print
 
@@ -1328,12 +1333,41 @@ def do_push_hg(parser):
 
     return success
 
+def delete_bookmark(parser, ref):
+    bmark = ref[len('refs/heads/'):]
+    if bmark == fake_bmark:
+        return False
+    # delete local (proxy or target)
+    old = bmarks[bmark].hex() if bmark in bmarks else ''
+    if not old:
+        return False
+    ok = False
+    if old:
+        ok = bookmarks.pushbookmark(parser.repo, bmark, old, '')
+        # propagate to peer if appropriate
+        if ok and peer:
+            remote_bmarks = peer.listkeys('bookmarks')
+            old = remote_bmarks.get(bmark, '')
+            ok = peer.pushkey('bookmarks', bmark, old, '')
+        # delete private ref
+        if ok:
+            pbookmark = '%s/bookmarks/%s' % (prefix, bmark)
+            subprocess.call(['git', 'update-ref', '-d', pbookmark])
+    return ok
+
 def do_push_refspec(parser, refspec):
     global force_push
 
     force = (refspec[0] == '+')
     refs = refspec.strip('+').split(':')
-    # only basic refs supported, no renames etc
+    # check for delete
+    if (not refs[0]) and refs[1].startswith('refs/heads'):
+        if not delete_bookmark(parser, refs[1]):
+            print "error %s could not delete"% (refs[1])
+        else:
+            print "ok %s" % (refs[1])
+        return
+    # only basic refs supported, no renames
     # may not be all one would expect from a native push (but hg is not native)
     # but it covers at least as much as the export capability supports
     if refs[0] != refs[1] or \

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -153,7 +153,7 @@ class Marks:
 
         tmp = json.load(open(self.path))
 
-        self.tips = tmp['tips']
+        self.tips = []
         self.marks = tmp['marks']
         self.last_mark = tmp['last-mark']
         self.version = tmp.get('version', 1)
@@ -204,11 +204,6 @@ class Marks:
     def is_marked(self, rev):
         return rev in self.marks
 
-    def get_tip(self, branch):
-        return str(self.tips[branch])
-
-    def set_tip(self, branch, tip):
-        self.tips[branch] = tip
 
 class ParserContext:
 
@@ -525,16 +520,8 @@ def revwalk(repo, name, b):
 
 def export_ref(repo, name, kind, head):
     ename = '%s/%s' % (kind, name)
-    try:
-        tip = marks.get_tip(ename)
-        tip = repo[tip]
-    except:
-        tip = repo[-1]
-
     revs = revwalk(repo, ename, head)
-
     total = len(revs)
-    tip = tip.rev()
 
     for progress, rev in enumerate(revs):
 
@@ -652,8 +639,6 @@ def export_ref(repo, name, kind, head):
         print
 
         marks.last_note = note_mark
-
-    marks.set_tip(ename, head.hex())
 
 def export_tag(repo, tag):
     export_ref(repo, tag, 'tags', repo[hgref(tag)])
@@ -1255,15 +1240,6 @@ def push(repo, remote, p_revs, force):
 
     return ret
 
-def check_tip(ref, kind, name, heads):
-    try:
-        ename = '%s/%s' % (kind, name)
-        tip = marks.get_tip(ename)
-    except KeyError:
-        return True
-    else:
-        return tip in heads
-
 def do_export(parser):
     do_push_hg(parser)
     print
@@ -1308,8 +1284,6 @@ def do_push_hg(parser):
         else:
             die('unhandled export command: %s' % line)
 
-    need_fetch = False
-
     for ref, node in parsed_refs.iteritems():
         bnode = hgbin(node) if node else None
         if ref.startswith('refs/heads/branches'):
@@ -1318,15 +1292,6 @@ def do_push_hg(parser):
                 # up to date
                 print "ok %s up to date" % ref
                 continue
-
-            if peer:
-                remotemap = peer.branchmap()
-                if remotemap and branch in remotemap:
-                    heads = [hghex(e) for e in remotemap[branch]]
-                    if not check_tip(ref, 'branches', branch, heads):
-                        print "error %s fetch first" % ref
-                        need_fetch = True
-                        continue
 
             p_revs[bnode] = ref
             print "ok %s" % ref
@@ -1343,14 +1308,6 @@ def do_push_hg(parser):
             if bmark != fake_bmark and \
                     not (bmark == 'master' and bmark not in parser.repo._bookmarks):
                 p_bmarks.append((ref, bmark, old, new))
-
-            if peer:
-                remote_old = peer.listkeys('bookmarks').get(bmark)
-                if remote_old:
-                    if not check_tip(ref, 'bookmarks', bmark, remote_old):
-                        print "error %s fetch first" % ref
-                        need_fetch = True
-                        continue
 
             p_revs[bnode] = ref
         elif ref.startswith('refs/tags/'):
@@ -1374,9 +1331,6 @@ def do_push_hg(parser):
         else:
             # transport-helper/fast-export bugs
             continue
-
-    if need_fetch:
-        return
 
     if dry_run:
         if peer and not force_push:

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -116,6 +116,12 @@ def rev_parse(rev):
     output, _ = process.communicate()
     return output
 
+def get_rev_hg(commit):
+    cmd = ['git', 'notes', '--ref', 'refs/notes/hg', 'show', commit]
+    process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    hgrev, _ = process.communicate()
+    return hgrev
+
 class Marks:
 
     def __init__(self, path, repo):
@@ -204,12 +210,21 @@ class Marks:
     def set_tip(self, branch, tip):
         self.tips[branch] = tip
 
+class ParserContext:
+
+    def __init__(self):
+        # known context attributes
+        self.localref = None
+        self.remoteref = None
+        self.gitmarks = None
+
 class Parser:
 
-    def __init__(self, repo, cmdstream=sys.stdin):
+    def __init__(self, repo, cmdstream=sys.stdin, ctx=ParserContext()):
         self.repo = repo
         self.cmdstream = cmdstream
         self.line = self.get_line()
+        self.context = ctx
 
     def get_line(self):
         return self.cmdstream.readline().strip()
@@ -837,7 +852,8 @@ def c_style_unescape(string):
 def parse_commit(parser):
     from_mark = merge_mark = None
 
-    ref = parser[1]
+    remoteref = parser.context.remoteref
+    ref = parser[1] if not remoteref else remoteref
     parser.next()
 
     commit_mark = parser.get_mark()
@@ -986,7 +1002,8 @@ def parse_commit(parser):
     marks.new_mark(node, commit_mark)
 
 def parse_reset(parser):
-    ref = parser[1]
+    remoteref = parser.context.remoteref
+    ref = parser[1] if not remoteref else remoteref
     parser.next()
     # ugh
     if parser.check('commit'):
@@ -1219,6 +1236,22 @@ def do_push_hg(parser):
 
     parser.next()
 
+    remoteref = parser.context.remoteref
+    if remoteref and not parser.line:
+        # if remoteref is in past exported
+        # git-fast-export might not produce anything at all
+        # that is ok'ish, we will determine parsed_ref another way
+        localref = parser.context.localref
+        hgrev = get_rev_hg(localref)
+        if not hgrev:
+            # maybe the notes are not updated
+            # happens only on fetch for now ... let's ask for that
+            print "error %s fetch first" % remoteref
+            return False
+        parsed_refs[remoteref] = hgrev
+        # now make parser happy
+        parser.line = 'done'
+
     for line in parser.each_block('done'):
         if parser.check('blob'):
             parse_blob(parser)
@@ -1361,19 +1394,26 @@ def do_push_refspec(parser, refspec):
     force = (refspec[0] == '+')
     refs = refspec.strip('+').split(':')
     # check for delete
-    if (not refs[0]) and refs[1].startswith('refs/heads'):
+    if (not refs[0]) and refs[1].startswith('refs/heads') and \
+            not refs[1].startswith('refs/heads/branches'):
         if not delete_bookmark(parser, refs[1]):
             print "error %s could not delete"% (refs[1])
         else:
             print "ok %s" % (refs[1])
         return
-    # only basic refs supported, no renames
-    # may not be all one would expect from a native push (but hg is not native)
-    # but it covers at least as much as the export capability supports
-    if refs[0] != refs[1] or \
-            not (refs[0].startswith('refs/heads') or refs[0].startswith('refs/tags')):
-        print "error %s refspec %s not supported " % (refs[1], refspec)
+    # sanity check on remote ref
+    if not (refs[1].startswith('refs/heads') or refs[1].startswith('refs/tags')):
+        print "error %s refspec not supported " % refs[1]
         return
+    ctx = ParserContext()
+    if refs[0] != refs[1]:
+        # would work and tag as requested, but pushing to a hg permanent branch
+        # based on a rename rather than a git branch is probably not a good idea
+        if refs[1].startswith('refs/heads/branches'):
+            print "error %s not allowed for permanent branch" % refs[1]
+            return
+        ctx.remoteref = refs[1]
+        ctx.localref = refs[0]
     # ok, fire up git-fast-export and process it
     cmd = ['git', 'fast-export', '--use-done-feature']
     fast_export_options = get_config('remote-hg.fast-export-options')
@@ -1396,7 +1436,7 @@ def do_push_refspec(parser, refspec):
     force_push = force
     ok = False
     try:
-        ok = do_push_hg(Parser(parser.repo, export.stdout))
+        ok = do_push_hg(Parser(parser.repo, export.stdout, ctx))
     finally:
         if tmpmarks and os.path.exists(tmpmarks):
             if ok and not dry_run:

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -206,12 +206,13 @@ class Marks:
 
 class Parser:
 
-    def __init__(self, repo):
+    def __init__(self, repo, cmdstream=sys.stdin):
         self.repo = repo
+        self.cmdstream = cmdstream
         self.line = self.get_line()
 
     def get_line(self):
-        return sys.stdin.readline().strip()
+        return self.cmdstream.readline().strip()
 
     def __getitem__(self, i):
         return self.line.split()[i]
@@ -241,7 +242,7 @@ class Parser:
             return None
         i = self.line.index(' ') + 1
         size = int(self.line[i:])
-        return sys.stdin.read(size)
+        return self.cmdstream.read(size)
 
     def get_author(self):
         ex = None
@@ -649,7 +650,10 @@ def export_head(repo):
 
 def do_capabilities(parser):
     print "import"
-    print "export"
+    if capability_push:
+        print "push"
+    else:
+        print "export"
     print "refspec refs/heads/branches/*:%s/branches/*" % prefix
     print "refspec refs/heads/*:%s/bookmarks/*" % prefix
     print "refspec refs/tags/*:%s/tags/*" % prefix
@@ -710,20 +714,28 @@ def do_list(parser):
 
     list_head(repo, cur)
 
+    # for export command a ref's old_sha1 is taken from private namespace ref
+    # for push command a fake one is provided
+    # that avoids having the ref status reported as a new branch/tag
+    # (though it will be marked as FETCH_FIRST prior to push,
+    # but that's ok as we will provide proper status)
+    for_push = (parser.line.find('for-push') >= 0)
+    sha1 = 'f' * 40 if (capability_push and for_push) else '?'
+
     if track_branches:
         for branch in branches:
-            print "? refs/heads/branches/%s" % gitref(branch)
+            print "%s refs/heads/branches/%s" % (sha1, gitref(branch))
 
     for bmark in bmarks:
         if bmarks[bmark].hex() == '0' * 40:
             warn("Ignoring invalid bookmark '%s'", bmark)
         else:
-            print "? refs/heads/%s" % gitref(bmark)
+            print "%s refs/heads/%s" % (sha1, gitref(bmark))
 
     for tag, node in repo.tagslist():
         if tag == 'tip':
             continue
-        print "? refs/tags/%s" % gitref(tag)
+        print "%s refs/tags/%s" % (sha1, gitref(tag))
 
     print
 
@@ -1189,8 +1201,16 @@ def check_tip(ref, kind, name, heads):
         return tip in heads
 
 def do_export(parser):
+    do_push_hg(parser)
+    print
+
+def do_push_hg(parser):
+    global parsed_refs, parsed_tags
     p_bmarks = []
     p_revs = {}
+
+    parsed_refs = {}
+    parsed_tags = {}
 
     parser.next()
 
@@ -1216,6 +1236,7 @@ def do_export(parser):
             branch = ref[len('refs/heads/branches/'):]
             if branch in branches and bnode in branches[branch]:
                 # up to date
+                print "ok %s up to date" % ref
                 continue
 
             if peer:
@@ -1235,6 +1256,7 @@ def do_export(parser):
             old = bmarks[bmark].hex() if bmark in bmarks else ''
 
             if old == new:
+                print "ok %s up to date" % ref
                 continue
 
             print "ok %s" % ref
@@ -1274,21 +1296,19 @@ def do_export(parser):
             continue
 
     if need_fetch:
-        print
         return
 
     if dry_run:
         if peer and not force_push:
             checkheads(parser.repo, peer, p_revs)
-        print
         return
 
+    success = True
     if peer:
         ret = push(parser.repo, peer, parsed_refs, p_revs)
         # None ok: nothing to push
         if ret != None and not ret:
             # do not update bookmarks
-            print
             return
 
         # update remote bookmarks
@@ -1297,13 +1317,71 @@ def do_export(parser):
             if force_push:
                 old = remote_bmarks.get(bmark, '')
             if not peer.pushkey('bookmarks', bmark, old, new):
+                success = False
                 print "error %s" % ref
     else:
         # update local bookmarks
         for ref, bmark, old, new in p_bmarks:
             if not bookmarks.pushbookmark(parser.repo, bmark, old, new):
+                success = False
                 print "error %s" % ref
 
+    return success
+
+def do_push_refspec(parser, refspec):
+    global force_push
+
+    force = (refspec[0] == '+')
+    refs = refspec.strip('+').split(':')
+    # only basic refs supported, no renames etc
+    # may not be all one would expect from a native push (but hg is not native)
+    # but it covers at least as much as the export capability supports
+    if refs[0] != refs[1] or \
+            not (refs[0].startswith('refs/heads') or refs[0].startswith('refs/tags')):
+        print "error %s refspec %s not supported " % (refs[1], refspec)
+        return
+    # ok, fire up git-fast-export and process it
+    cmd = ['git', 'fast-export', '--use-done-feature']
+    fast_export_options = get_config('remote-hg.fast-export-options')
+    if not fast_export_options:
+        fast_export_options = '-M -C'
+    cmd.extend(fast_export_options.strip().split())
+    marks = os.path.join(dirname, 'marks-git')
+    if os.path.exists(marks):
+        cmd.append('--import-marks=%s' % marks)
+    # no commit of marks if dry-dry_run
+    # and only commit if all went ok,
+    # otherwise some commits may no longer be exported next time/try around
+    tmpmarks = ''
+    if not dry_run:
+        tmpmarks = os.path.join(dirname, 'marks-git-%d' % (os.getpid()))
+        cmd.append('--export-marks=%s' % tmpmarks)
+    cmd.append(refs[0])
+    export = subprocess.Popen(cmd, stdin=None, stdout=subprocess.PIPE)
+    # a parameter would obviously be nicer here ...
+    force_push = force
+    ok = False
+    try:
+        ok = do_push_hg(Parser(parser.repo, export.stdout))
+    finally:
+        if tmpmarks and os.path.exists(tmpmarks):
+            if ok and not dry_run:
+                # the commits made it through, now we can commit
+                os.rename(tmpmarks, marks)
+            else:
+                os.remove(tmpmarks)
+
+def do_push(parser):
+    if os.environ.get('GIT_REMOTE_HG_DEBUG_PUSH'):
+        dump = ''
+        for line in parser:
+            dump += line + '\n'
+        die('DEBUG push:\n%s' % (dump))
+    for line in parser:
+        if parser.check('push'):
+            do_push_refspec(parser, line.lstrip('push '))
+        else:
+            die('unhandled push command: %s' % (line))
     print
 
 def do_option(parser):
@@ -1336,6 +1414,7 @@ def main(args):
     global fake_bmark, hg_version
     global dry_run
     global notes, alias
+    global capability_push
 
     marks = None
     is_tmp = False
@@ -1353,6 +1432,7 @@ def main(args):
 
     hg_git_compat = get_config_bool('remote-hg.hg-git-compat')
     track_branches = get_config_bool('remote-hg.track-branches', True)
+    capability_push = get_config_bool('remote-hg.capability-push', True)
     force_push = False
 
     if hg_git_compat:
@@ -1372,8 +1452,6 @@ def main(args):
     branches = {}
     bmarks = {}
     blob_marks = {}
-    parsed_refs = {}
-    parsed_tags = {}
     filenodes = {}
     fake_bmark = None
     try:
@@ -1410,6 +1488,8 @@ def main(args):
             do_import(parser)
         elif parser.check('export'):
             do_export(parser)
+        elif parser.check('push'):
+            do_push(parser)
         elif parser.check('option'):
             do_option(parser)
         else:

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -778,17 +778,7 @@ def get_file_metadata(repo, p1, files):
         if 'rename' in f and 'mode' not in f:
             old = f['rename']
             ctx = repo[p1][old]
-            m = ''
-            # .isexec(), .islink() only around in newer versions
-            if hasattr(ctx, 'isexec'):
-                m = ctx.isexec()
-            else:
-                m = ('x' in ctx.flags())
-            if hasattr(ctx, 'islink'):
-                m = ctx.islink()
-            else:
-                m = ('l' in ctx.flags())
-            f['mode'] = m
+            f['mode'] = ctx.flags()
             f['data'] = ctx.data()
 
 def get_merge_files(repo, p1, p2, files):

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -1445,6 +1445,7 @@ def do_push_refspec(parser, refspec, revs):
             subprocess.check_call(cmd, stdin=None, stdout=tmpfastexport)
             try:
                 import imp
+                sys.dont_write_bytecode = True
                 ctx.hghelper = imp.load_source('hghelper', \
                     os.path.join(os.path.dirname(__file__), 'git-hg-helper'))
                 ctx.hghelper.init_git(gitdir)

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -1383,7 +1383,7 @@ def delete_bookmark(parser, ref):
             ok = peer.pushkey('bookmarks', bmark, old, '')
         # delete private ref
         if ok:
-            pbookmark = '%s/bookmarks/%s' % (prefix, bmark)
+            pbookmark = '%s/heads/%s' % (prefix, bmark)
             subprocess.call(['git', 'update-ref', '-d', pbookmark])
     return ok
 

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -510,10 +510,10 @@ def revwalk(repo, name, b):
     positive = []
     pending = set()
     if not marks.is_marked(b.hex()):
-        pending.add(int(b))
-    interval = int(b) / 10
+        pending.add(b.rev())
+    interval = b.rev() / 10
     interval = interval if interval > 1000 else 1000
-    for cur in xrange(b, -1, -1):
+    for cur in xrange(b.rev(), -1, -1):
         if not pending:
             break
 
@@ -526,7 +526,7 @@ def revwalk(repo, name, b):
                     pending.add(p)
 
         if cur % interval == 0:
-            print "progress revision walk '%s' (%d/%d)" % (name, (int(b) - cur), int(b))
+            print "progress revision walk '%s' (%d/%d)" % (name, (b.rev() - cur), b.rev())
 
     positive.reverse()
     return positive

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -530,7 +530,7 @@ def export_ref(repo, name, kind, head):
     total = len(revs)
     tip = tip.rev()
 
-    for rev in revs:
+    for progress, rev in enumerate(revs):
 
         c = repo[rev]
         node = c.node()
@@ -611,7 +611,6 @@ def export_ref(repo, name, kind, head):
             print "M %s :%u %s" % f
         print
 
-        progress = (rev - tip)
         if (progress % 100 == 0):
             print "progress revision %d '%s' (%d/%d)" % (rev, name, progress, total)
 

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -427,7 +427,7 @@ def updatebookmarks(repo, peer):
 def get_repo(url, alias):
     global peer
 
-    myui = ui.ui()
+    myui = ui.ui.load()
     myui.setconfig('ui', 'interactive', 'off')
     myui.fout = sys.stderr
 

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -456,6 +456,7 @@ def get_repo(url, alias):
         repo = hg.repository(myui, url)
         if not os.path.exists(dirname):
             os.makedirs(dirname)
+        branchmap = repo.branchmap()
     else:
         shared_path = os.path.join(gitdir, 'hg')
 

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -86,10 +86,10 @@ def hgbin(n):
     return node.bin(n)
 
 def hgref(ref):
-    return ref.replace('___', ' ')
+    return ref.replace('___', ' ').replace('%5F%5F%5F', '___')
 
 def gitref(ref):
-    return ref.replace(' ', '___')
+    return ref.replace('___', '%5F%5F%5F').replace(' ', '___')
 
 def check_version(*check):
     if not hg_version:

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -493,15 +493,20 @@ def get_repo(url, alias):
         except:
             die('Repository error')
 
+        branchmap = peer.branchmap()
+        heads = []
+        for branch, branch_heads in branchmap.iteritems():
+            heads.extend(branch_heads)
+
         if check_version(3, 0):
             from mercurial import exchange
-            exchange.pull(repo, peer, heads=None, force=True)
+            exchange.pull(repo, peer, heads=heads, force=True)
         else:
-            repo.pull(peer, heads=None, force=True)
+            repo.pull(peer, heads=heads, force=True)
 
         updatebookmarks(repo, peer)
 
-    return repo
+    return repo, branchmap
 
 def rev_to_mark(rev):
     return marks.from_rev(rev.hex())
@@ -704,15 +709,14 @@ def list_head(repo, cur):
     print "@refs/heads/%s HEAD" % head
     g_head = (head, node)
 
-def do_list(parser):
+def do_list(parser, branchmap):
     repo = parser.repo
     for bmark, node in bookmarks.listbookmarks(repo).iteritems():
         bmarks[bmark] = repo[node]
 
     cur = repo.dirstate.branch()
-    orig = peer if peer else repo
 
-    for branch, heads in orig.branchmap().iteritems():
+    for branch, heads in branchmap.iteritems():
         # only open heads
         heads = [h for h in heads if 'close' not in repo.changelog.read(h)[5]]
         if heads:
@@ -1761,7 +1765,7 @@ def main(args):
 
     prefix = select_private_refs(alias)
     marksdir = select_marks_dir(alias, gitdir, True)
-    repo = get_repo(url, alias)
+    repo, branchmap = get_repo(url, alias)
 
     if not is_tmp:
         fix_path(alias, peer or repo, url)
@@ -1778,7 +1782,7 @@ def main(args):
         if parser.check('capabilities'):
             do_capabilities(parser)
         elif parser.check('list'):
-            do_list(parser)
+            do_list(parser, branchmap)
         elif parser.check('import'):
             do_import(parser)
         elif parser.check('export'):

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,53 @@
+# git-remote-hg setuptools script
+
+import setuptools
+import subprocess
+import sys
+import os
+
+# derive version from git repo
+cmd = ["git", "describe", "--tags"]
+commit = os.environ.get('REV', None)
+if commit:
+  cmd.append(commit)
+process = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+version = process.communicate()[0].strip()
+# strip leading v
+version = version[1:]
+
+# check for released version
+assert (len(version) > 0)
+assert (version.find('-') < 0)
+
+long_description = \
+"""
+'git-remote-hg' is a gitremote protocol helper for Mercurial.
+It allows you to clone, fetch and push to and from Mercurial repositories as if
+they were Git ones using a hg::some-url URL.
+
+See the homepage for much more explanation.
+"""
+
+CLASSIFIERS = [
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 2",
+    "Programming Language :: Python :: 2.7",
+    "License :: OSI Approved",
+    "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+]
+
+setuptools.setup(name="git-remote-hg",
+      version=version,
+      author="Mark Nauwelaerts",
+      author_email="mnauw@users.sourceforge.net",
+      url="http://github.com/mnauw/git-remote-hg",
+      description="access hg repositories as git remotes",
+      long_description=long_description,
+      license="GPLv2",
+      keywords="git hg mercurial",
+      scripts=["git-remote-hg", "git-hg-helper"],
+      classifiers=CLASSIFIERS
+     )
+

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import sys
 import os
 
 # strip leading v
-version = 'v1.0.1'
+version = 'v1.0.1'[1:]
 
 # check for released version
 assert (len(version) > 0)

--- a/setup.py
+++ b/setup.py
@@ -5,15 +5,8 @@ import subprocess
 import sys
 import os
 
-# derive version from git repo
-cmd = ["git", "describe", "--tags"]
-commit = os.environ.get('REV', None)
-if commit:
-  cmd.append(commit)
-process = subprocess.Popen(cmd, stdout=subprocess.PIPE)
-version = process.communicate()[0].strip()
 # strip leading v
-version = version[1:]
+version = 'v1.0.0'
 
 # check for released version
 assert (len(version) > 0)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import sys
 import os
 
 # strip leading v
-version = 'v1.0.0'
+version = 'v1.0.1'
 
 # check for released version
 assert (len(version) > 0)

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,6 +1,6 @@
 RM ?= rm -f
 
-T = main.t main-push.t bidi.t
+T = main.t main-push.t bidi.t helper.t
 TEST_DIRECTORY := $(CURDIR)
 
 export TEST_DIRECTORY

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,6 +1,6 @@
 RM ?= rm -f
 
-T = main.t bidi.t
+T = main.t main-push.t bidi.t
 TEST_DIRECTORY := $(CURDIR)
 
 export TEST_DIRECTORY

--- a/test/bidi.t
+++ b/test/bidi.t
@@ -51,7 +51,7 @@ hg_push () {
 }
 
 hg_log () {
-	hg -R $1 log --graph --debug
+	hg -R $1 log --debug
 }
 
 setup () {
@@ -204,8 +204,9 @@ test_expect_success 'hg branch' '
 	: Back to the common revision &&
 	(cd hgrepo && hg checkout default) &&
 
-	hg_log hgrepo > expected &&
-	hg_log hgrepo2 > actual &&
+	# fetch does not affect phase, but pushing now does
+	hg_log hgrepo | grep -v phase > expected &&
+	hg_log hgrepo2 | grep -v phase > actual &&
 
 	test_cmp expected actual
 '
@@ -232,10 +233,12 @@ test_expect_success 'hg tags' '
 	) &&
 
 	hg_push hgrepo gitrepo &&
-	hg_clone gitrepo hgrepo2 &&
+	# pushing a fetched tag is a problem ...
+	{ hg_clone gitrepo hgrepo2 || true ; } &&
 
-	hg_log hgrepo > expected &&
-	hg_log hgrepo2 > actual &&
+	# fetch does not affect phase, but pushing now does
+	hg_log hgrepo | grep -v phase > expected &&
+	hg_log hgrepo2 | grep -v phase > actual &&
 
 	test_cmp expected actual
 '

--- a/test/helper.t
+++ b/test/helper.t
@@ -147,7 +147,7 @@ test_expect_success 'subcommand gc' '
 	git fetch origin &&
 	git reset --hard origin/master &&
 	git gc &&
-	git-hg-helper gc origin > output &&
+	git-hg-helper gc --check-hg origin > output &&
 	cat output &&
 	grep "hg marks" output &&
 	grep "git marks" output

--- a/test/helper.t
+++ b/test/helper.t
@@ -64,6 +64,7 @@ test_expect_success 'subcommand help' '
 	grep origin help
 '
 
+git config --global remote-hg.shared-marks false
 test_expect_success 'subcommand repo - no local proxy' '
 	test_when_finished "rm -rf gitrepo* hgrepo*" &&
 
@@ -81,6 +82,8 @@ test_expect_success 'subcommand repo - no local proxy' '
 
 	test_cmp expected actual
 '
+
+git config --global --unset remote-hg.shared-marks
 
 GIT_REMOTE_HG_TEST_REMOTE=1 &&
 export GIT_REMOTE_HG_TEST_REMOTE

--- a/test/helper.t
+++ b/test/helper.t
@@ -30,6 +30,8 @@ setup () {
 	[extensions]
 	mq =
 	strip =
+	[subrepos]
+	git:allowed = true
 	EOF
 
 	GIT_AUTHOR_DATE="2007-01-01 00:00:00 +0230" &&

--- a/test/helper.t
+++ b/test/helper.t
@@ -1,0 +1,179 @@
+#!/bin/sh
+#
+# Copyright (c) 2016 Mark Nauwelaerts
+#
+# Base commands from hg-git tests:
+# https://bitbucket.org/durin42/hg-git/src
+#
+
+test_description='Test git-hg-helper'
+
+test -n "$TEST_DIRECTORY" || TEST_DIRECTORY=$(dirname $0)/
+. "$TEST_DIRECTORY"/test-lib.sh
+
+if ! test_have_prereq PYTHON
+then
+	skip_all='skipping remote-hg tests; python not available'
+	test_done
+fi
+
+if ! python2 -c 'import mercurial' > /dev/null 2>&1
+then
+	skip_all='skipping remote-hg tests; mercurial not available'
+	test_done
+fi
+
+setup () {
+	cat > "$HOME"/.hgrc <<-EOF &&
+	[ui]
+	username = H G Wells <wells@example.com>
+	[extensions]
+	mq =
+	strip =
+	EOF
+
+	GIT_AUTHOR_DATE="2007-01-01 00:00:00 +0230" &&
+	GIT_COMMITTER_DATE="$GIT_AUTHOR_DATE" &&
+	export GIT_COMMITTER_DATE GIT_AUTHOR_DATE
+}
+
+setup
+
+setup_repos () {
+	(
+	hg init hgrepo &&
+	cd hgrepo &&
+	echo zero > content &&
+	hg add content &&
+	hg commit -m zero
+	) &&
+
+	git clone hg::hgrepo gitrepo
+}
+
+test_expect_success 'subcommand help' '
+	test_when_finished "rm -rf gitrepo* hgrepo*" &&
+
+	setup_repos &&
+
+	(
+	cd gitrepo &&
+	test_expect_code 2 git-hg-helper help 2> ../help
+	)
+	# remotes should be in help output
+	grep origin help
+'
+
+test_expect_success 'subcommand repo - no local proxy' '
+	test_when_finished "rm -rf gitrepo* hgrepo*" &&
+
+	setup_repos &&
+
+	(
+	cd hgrepo &&
+	pwd >../expected
+	) &&
+
+	(
+	cd gitrepo &&
+	git-hg-helper repo origin > ../actual
+	) &&
+
+	test_cmp expected actual
+'
+
+GIT_REMOTE_HG_TEST_REMOTE=1 &&
+export GIT_REMOTE_HG_TEST_REMOTE
+
+test_expect_success 'subcommand repo - with local proxy' '
+	test_when_finished "rm -rf gitrepo* hgrepo*" &&
+
+	setup_repos &&
+
+	(
+	cd gitrepo &&
+	export gitdir=`git rev-parse --git-dir`
+	# trick to normalize path
+	( cd $gitdir/hg/origin/clone && pwd ) >../expected &&
+	( cd `git-hg-helper repo origin` && pwd ) > ../actual
+	) &&
+
+	test_cmp expected actual
+'
+
+test_expect_success 'subcommands hg-rev and git-rev' '
+	test_when_finished "rm -rf gitrepo* hgrepo*" &&
+
+	setup_repos &&
+
+	(
+	cd gitrepo &&
+	git rev-parse HEAD > rev-HEAD &&
+	test -s rev-HEAD &&
+	git-hg-helper hg-rev `cat rev-HEAD` > hg-HEAD &&
+	git-hg-helper git-rev `cat hg-HEAD` > git-HEAD &&
+	test_cmp rev-HEAD git-HEAD
+	)
+'
+
+test_expect_success 'subcommand mark' '
+	test_when_finished "rm -rf gitrepo* hgrepo*" &&
+
+	(
+	hg init hgrepo &&
+	cd hgrepo &&
+	echo zero > content &&
+	hg add content &&
+	hg commit -m zero
+	echo one > content &&
+	hg commit -m one &&
+	echo two > content &&
+	hg commit -m two &&
+	echo three > content &&
+	hg commit -m three &&
+	hg identify -r 0 --id >../root
+	) &&
+
+	hgroot=`cat root` &&
+
+	git clone hg::hgrepo gitrepo &&
+
+	(
+	cd hgrepo &&
+	hg strip -r 1
+	) &&
+
+	(
+	cd gitrepo &&
+	git-hg-helper marks origin --keep $hgroot  > output &&
+	cat output &&
+	grep "hg marks" output &&
+	grep "git marks" output &&
+	grep "Updated" output | grep $hgroot
+	)
+'
+
+test_expect_success 'subcommand [some-repo]' '
+	test_when_finished "rm -rf gitrepo* hgrepo*" &&
+
+	setup_repos &&
+
+	(
+	cd hgrepo &&
+	echo one > content &&
+	hg commit -m one
+	) &&
+
+	(
+	cd gitrepo &&
+	git fetch origin
+	) &&
+
+	hg log -R hgrepo > expected &&
+	# not inside gitrepo; test shared path handling
+	GIT_DIR=gitrepo/.git git-hg-helper origin log > actual
+
+	test_cmp expected actual
+'
+
+test_done

--- a/test/helper.t
+++ b/test/helper.t
@@ -116,7 +116,7 @@ test_expect_success 'subcommands hg-rev and git-rev' '
 	)
 '
 
-test_expect_success 'subcommand mark' '
+test_expect_success 'subcommand gc' '
 	test_when_finished "rm -rf gitrepo* hgrepo*" &&
 
 	(
@@ -130,26 +130,27 @@ test_expect_success 'subcommand mark' '
 	echo two > content &&
 	hg commit -m two &&
 	echo three > content &&
-	hg commit -m three &&
-	hg identify -r 0 --id >../root
+	hg commit -m three
 	) &&
-
-	hgroot=`cat root` &&
 
 	git clone hg::hgrepo gitrepo &&
 
 	(
 	cd hgrepo &&
-	hg strip -r 1
+	hg strip -r 1 &&
+	echo four > content &&
+	hg commit -m four
 	) &&
 
 	(
 	cd gitrepo &&
-	git-hg-helper marks origin --keep $hgroot  > output &&
+	git fetch origin &&
+	git reset --hard origin/master &&
+	git gc &&
+	git-hg-helper gc origin > output &&
 	cat output &&
 	grep "hg marks" output &&
-	grep "git marks" output &&
-	grep "Updated" output | grep $hgroot
+	grep "git marks" output
 	)
 '
 

--- a/test/main-push.t
+++ b/test/main-push.t
@@ -29,4 +29,36 @@ test_expect_success 'remote delete bookmark' '
 	check_bookmark hgrepo feature-a ''
 '
 
+test_expect_success 'source:dest bookmark' '
+	test_when_finished "rm -rf hgrepo gitrepo" &&
+
+	(
+	hg init hgrepo &&
+	cd hgrepo &&
+	echo zero > content &&
+	hg add content &&
+	hg commit -m zero
+	) &&
+
+	git clone "hg::hgrepo" gitrepo &&
+
+	(
+	cd gitrepo &&
+	echo one > content &&
+	git commit -a -m one &&
+	git push --quiet origin master:feature-b &&
+	git push --quiet origin master^:refs/heads/feature-a
+	) &&
+
+	check_bookmark hgrepo feature-a zero &&
+	check_bookmark hgrepo feature-b one &&
+
+	(
+	cd gitrepo &&
+	git push --quiet origin master:feature-a
+	) &&
+
+	check_bookmark hgrepo feature-a one
+'
+
 test_done

--- a/test/main-push.t
+++ b/test/main-push.t
@@ -3,3 +3,30 @@ CAPABILITY_PUSH=t
 test -n "$TEST_DIRECTORY" || TEST_DIRECTORY=$(dirname $0)/
 . "$TEST_DIRECTORY"/main.t
 
+
+# .. and some push mode only specific tests
+
+test_expect_success 'remote delete bookmark' '
+	test_when_finished "rm -rf hgrepo* gitrepo*" &&
+
+	(
+	hg init hgrepo &&
+	cd hgrepo &&
+	echo zero > content &&
+	hg add content &&
+	hg commit -m zero
+	hg bookmark feature-a
+	) &&
+
+	git clone "hg::hgrepo" gitrepo &&
+	check_bookmark hgrepo feature-a zero &&
+
+	(
+	cd gitrepo &&
+	git push --quiet origin :feature-a
+	) &&
+
+	check_bookmark hgrepo feature-a ''
+'
+
+test_done

--- a/test/main-push.t
+++ b/test/main-push.t
@@ -273,7 +273,8 @@ test_expect_success 'push with renamed executable preserves executable bit' '
 	cd hgrepo &&
 	hg update &&
 	stat content2 >expected &&
-	grep -- -rwxr-xr-x expected
+	# umask mileage might vary
+	grep -- -r.xr.xr.x expected
 	)
 '
 

--- a/test/main-push.t
+++ b/test/main-push.t
@@ -1,0 +1,5 @@
+CAPABILITY_PUSH=t
+
+test -n "$TEST_DIRECTORY" || TEST_DIRECTORY=$(dirname $0)/
+. "$TEST_DIRECTORY"/main.t
+

--- a/test/main-push.t
+++ b/test/main-push.t
@@ -251,6 +251,32 @@ test_expect_success 'shared-marks unset to set' '
 	)
 '
 
+test_expect_success 'push with renamed executable preserves executable bit' '
+	test_when_finished "rm -rf hgrepo gitrepo*" &&
+
+	hg init hgrepo &&
+
+	(
+	git init gitrepo &&
+	cd gitrepo &&
+	git remote add origin "hg::../hgrepo" &&
+	echo one > content &&
+	chmod a+x content &&
+	git add content &&
+	git commit -a -m one &&
+	git mv content content2 &&
+	git commit -a -m two &&
+	git push origin master
+	) &&
+
+	(
+	cd hgrepo &&
+	hg update &&
+	stat content2 >expected &&
+	grep -- -rwxr-xr-x expected
+	)
+'
+
 # cleanup setting
 git config --global --unset remote-hg.shared-marks
 

--- a/test/main-push.t
+++ b/test/main-push.t
@@ -278,6 +278,36 @@ test_expect_success 'push with renamed executable preserves executable bit' '
 	)
 '
 
+test_expect_success 'push with submodule' '
+	test_when_finished "rm -rf sub hgrepo gitrepo*" &&
+
+	hg init hgrepo &&
+
+	(
+	git init sub &&
+	cd sub &&
+	: >empty &&
+	git add empty &&
+	git commit -m init
+	) &&
+
+	(
+	git init gitrepo &&
+	cd gitrepo &&
+	git submodule add ../sub sub &&
+	git remote add origin "hg::../hgrepo" &&
+	git commit -a -m sub &&
+	git push origin master
+	) &&
+
+	(
+	cd hgrepo &&
+	hg update &&
+	expected="[git-remote-hg: skipped import of submodule at $(git -C ../sub rev-parse HEAD)]"
+	test "$expected" = "$(cat sub)"
+	)
+'
+
 # cleanup setting
 git config --global --unset remote-hg.shared-marks
 

--- a/test/main.t
+++ b/test/main.t
@@ -14,6 +14,7 @@ test -n "$TEST_DIRECTORY" || TEST_DIRECTORY=$(dirname $0)/
 if test "$CAPABILITY_PUSH" = "t"
 then
 	git config --global remote-hg.capability-push true
+	git config --global remote-hg.push-updates-notes true
 else
 	git config --global remote-hg.capability-push false
 fi
@@ -931,7 +932,8 @@ test_expect_success 'notes' '
 	test_cmp expected actual
 '
 
-test_expect_failure 'push updates notes' '
+testpushupdatesnotesdesc='push updates notes'
+testpushupdatesnotes='
 	test_when_finished "rm -rf hgrepo gitrepo" &&
 
 	(
@@ -955,6 +957,13 @@ test_expect_failure 'push updates notes' '
 	git --git-dir=gitrepo/.git log --pretty="tformat:%N" --notes=hg > actual &&
 	test_cmp expected actual
 '
+
+if test "$CAPABILITY_PUSH" = "t"
+then
+test_expect_success "$testpushupdatesnotesdesc" "$testpushupdatesnotes"
+else
+test_expect_failure "$testpushupdatesnotesdesc" "$testpushupdatesnotes"
+fi
 
 test_expect_success 'push bookmark without changesets' '
 	test_when_finished "rm -rf hgrepo gitrepo" &&

--- a/test/main.t
+++ b/test/main.t
@@ -15,6 +15,7 @@ if test "$CAPABILITY_PUSH" = "t"
 then
 	git config --global remote-hg.capability-push true
 	git config --global remote-hg.push-updates-notes true
+	git config --global remote-hg.fast-export-options '-C -C -M'
 else
 	git config --global remote-hg.capability-push false
 fi
@@ -489,7 +490,9 @@ testcopyrename='
 	(
 	cd gitrepo &&
 	cp content content-copy &&
-	echo one > content &&
+	# recent git-fast-export is (too) picky in recognizing copies
+	# although git-log is not as picky (????)
+	# echo one > content &&
 	git add content content-copy &&
 	git commit -m copy &&
 	git mv content-copy content-moved

--- a/test/main.t
+++ b/test/main.t
@@ -882,7 +882,7 @@ test_expect_failure 'push updates notes' '
 	test_cmp expected actual
 '
 
-test_expect_failure 'push bookmark without changesets' '
+test_expect_success 'push bookmark without changesets' '
 	test_when_finished "rm -rf hgrepo gitrepo" &&
 
 	(

--- a/test/main.t
+++ b/test/main.t
@@ -1152,4 +1152,7 @@ test_expect_success 'clone replace directory with a file' '
 	check_files gitrepo "dir_or_file"
 '
 
+if test "$CAPABILITY_PUSH" != "t"
+then
 test_done
+fi

--- a/test/main.t
+++ b/test/main.t
@@ -783,6 +783,35 @@ test_expect_success 'remote double failed push' '
 	test_expect_code 1 git push
 	)
 '
+test_expect_success 'fetch prune' '
+	test_when_finished "rm -rf gitrepo hgrepo" &&
+
+	(
+	hg init hgrepo &&
+	cd hgrepo &&
+	echo zero > content &&
+	hg add content &&
+	hg commit -m zero &&
+	echo feature-a > content &&
+	hg commit -m feature-a
+	hg bookmark feature-a
+	) &&
+
+	git clone "hg::hgrepo" gitrepo &&
+	check gitrepo origin/feature-a feature-a &&
+
+	(
+	cd hgrepo &&
+	hg bookmark -d feature-a
+	) &&
+
+	(
+	cd gitrepo &&
+	git fetch --prune origin
+	git branch -a > out &&
+	! grep feature-a out
+	)
+'
 
 test_expect_success 'clone remote with null bookmark, then push' '
 	test_when_finished "rm -rf gitrepo* hgrepo*" &&

--- a/test/main.t
+++ b/test/main.t
@@ -491,8 +491,11 @@ testcopyrename='
 	cd gitrepo &&
 	cp content content-copy &&
 	# recent git-fast-export is (too) picky in recognizing copies
-	# although git-log is not as picky (????)
-	# echo one > content &&
+	# although git-log is not as picky;
+	# since https://github.com/git/git/commit/8096e1d385660c159d9d47e69b2be63cf22e4f31
+	# a copy is only marked if source filed not modified as well
+	# (though destination file can be modified)
+	echo one >> content-copy &&
 	git add content content-copy &&
 	git commit -m copy &&
 	git mv content-copy content-moved

--- a/test/main.t
+++ b/test/main.t
@@ -1201,6 +1201,28 @@ test_expect_success 'clone replace directory with a file' '
 	check_files gitrepo "dir_or_file"
 '
 
+test_expect_success 'clone can ignore invalid refnames' '
+	test_when_finished "rm -rf hgrepo gitrepo" &&
+
+	(
+	hg init hgrepo &&
+	cd hgrepo &&
+
+	touch test.txt &&
+	hg add test.txt &&
+	hg commit -m master &&
+	hg branch parent &&
+	echo test >test.txt &&
+	hg commit -m test &&
+	hg branch parent/child &&
+	echo test1 >test.txt &&
+	hg commit -m test1
+	) &&
+
+	git clone -c remote-hg.ignore-name=child "hg::hgrepo" gitrepo &&
+	check_files gitrepo "test.txt"
+'
+
 if test "$CAPABILITY_PUSH" != "t"
 then
 test_done

--- a/test/main.t
+++ b/test/main.t
@@ -882,6 +882,31 @@ test_expect_failure 'push updates notes' '
 	test_cmp expected actual
 '
 
+test_expect_failure 'push bookmark without changesets' '
+	test_when_finished "rm -rf hgrepo gitrepo" &&
+
+	(
+	hg init hgrepo &&
+	cd hgrepo &&
+	echo one > content &&
+	hg add content &&
+	hg commit -m one
+	) &&
+
+	git clone "hg::hgrepo" gitrepo &&
+
+	(
+	cd gitrepo &&
+	echo two > content &&
+	git commit -a -m two &&
+	git push origin master &&
+	git branch feature-a &&
+	git push origin feature-a
+	) &&
+
+	check_bookmark hgrepo feature-a two
+'
+
 test_expect_success 'pull tags' '
 	test_when_finished "rm -rf hgrepo gitrepo" &&
 

--- a/test/main.t
+++ b/test/main.t
@@ -89,9 +89,6 @@ check_push () {
 		'non-fast-forward')
 			grep "^ ! \[rejected\] *${branch} -> ${branch} (non-fast-forward)$" error || ref_ret=1
 			;;
-		'fetch-first')
-			grep "^ ! \[rejected\] *${branch} -> ${branch} (fetch first)$" error || ref_ret=1
-			;;
 		'forced-update')
 			grep "^ + [a-f0-9]*\.\.\.[a-f0-9]* *${branch} -> ${branch} (forced update)$" error || ref_ret=1
 			;;
@@ -450,7 +447,7 @@ test_expect_success 'remote update bookmark diverge' '
 	echo diverge > content &&
 	git commit -a -m diverge &&
 	check_push 1 <<-\EOF
-	diverge:fetch-first
+	diverge:non-fast-forward
 	EOF
 	) &&
 
@@ -691,7 +688,7 @@ test_expect_success 'remote big push' '
 	fi
 '
 
-test_expect_success 'remote big push fetch first' '
+test_expect_success 'remote big push non fast forward' '
 	test_when_finished "rm -rf hgrepo gitrepo*" &&
 
 	(
@@ -740,8 +737,8 @@ test_expect_success 'remote big push fetch first' '
 	check_push 1 --all <<-\EOF &&
 	master
 	good_bmark
-	bad_bmark:fetch-first
-	branches/bad_branch:festch-first
+	bad_bmark:non-fast-forward
+	branches/bad_branch:non-fast-forward
 	EOF
 
 	git fetch &&

--- a/test/main.t
+++ b/test/main.t
@@ -796,7 +796,7 @@ test_expect_failure 'remote big push force' '
 	check_bookmark hgrepo new_bmark six
 '
 
-test_expect_failure 'remote big push dry-run' '
+test_expect_success 'remote big push dry-run' '
 	test_when_finished "rm -rf hgrepo gitrepo*" &&
 
 	setup_big_push


### PR DESCRIPTION
Hi! I've got a pull request to felipec repo https://github.com/felipec/git-remote-hg/pull/79, but it hungs there for a few months with no action.
Can you please check it and use in your fork?

